### PR TITLE
[Refactor] 로그인 로직 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,18 @@ src
 - 모든 커스텀 예외는 `BaseStatus` 기반으로 정의
 - HTTP Status 명확히 구분하여 반환
 
-### (6) 코드 리뷰 기준
+### (6) 설정
+
+- 로그인 세션 TTL은 `auth.login-session-expiration`으로 설정
+- 단위는 millisecond이며 기본값은 `300000`(5분)
+- 로컬/운영 설정 예시:
+
+```yaml
+auth:
+  login-session-expiration: 300000
+```
+
+### (7) 코드 리뷰 기준
 
 - 네이밍이 직관적인가
 - 각 클래스와 메서드의 책임이 명확한가

--- a/src/main/java/com/ssu/ongi/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/ssu/ongi/common/jwt/JwtTokenProvider.java
@@ -15,6 +15,9 @@ import java.util.Date;
 @Component
 public class JwtTokenProvider {
 
+    private static final String TOKEN_TYPE = "tokenType";
+    private static final String LOGIN_SESSION_TOKEN_TYPE = "LOGIN_SESSION";
+
     @Value("${jwt.access-secret}")
     private String accessSecret;
 
@@ -26,6 +29,9 @@ public class JwtTokenProvider {
 
     @Value("${jwt.refresh-expiration}")
     private long refreshExpiration;
+
+    @Value("${jwt.login-session-expiration:300000}")
+    private long loginSessionExpiration;
 
     private SecretKey accessKey;
     private SecretKey refreshKey;
@@ -57,6 +63,17 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    public String createLoginSessionToken(Long memberId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .claim(TOKEN_TYPE, LOGIN_SESSION_TOKEN_TYPE)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + loginSessionExpiration))
+                .signWith(accessKey)
+                .compact();
+    }
+
     // AccessToken에서 memberId 추출 (Filter에서 사용)
     public Long getMemberId(String token) {
         return Long.parseLong(getAccessClaims(token).getSubject());
@@ -65,6 +82,10 @@ public class JwtTokenProvider {
     // RefreshToken에서 memberId 추출 (재발급 시 사용)
     public Long getMemberIdFromRefresh(String token) {
         return Long.parseLong(getRefreshClaims(token).getSubject());
+    }
+
+    public Long getMemberIdFromLoginSession(String token) {
+        return Long.parseLong(getLoginSessionClaims(token).getSubject());
     }
 
     public LoginMode getLoginMode(String token) {
@@ -79,5 +100,13 @@ public class JwtTokenProvider {
     private Claims getRefreshClaims(String token) {
         return Jwts.parser().verifyWith(refreshKey).build()
                 .parseSignedClaims(token).getPayload();
+    }
+
+    private Claims getLoginSessionClaims(String token) {
+        Claims claims = getAccessClaims(token);
+        if (!LOGIN_SESSION_TOKEN_TYPE.equals(claims.get(TOKEN_TYPE, String.class))) {
+            throw new IllegalArgumentException("유효하지 않은 로그인 세션 토큰입니다.");
+        }
+        return claims;
     }
 }

--- a/src/main/java/com/ssu/ongi/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/ssu/ongi/common/jwt/JwtTokenProvider.java
@@ -15,9 +15,6 @@ import java.util.Date;
 @Component
 public class JwtTokenProvider {
 
-    private static final String TOKEN_TYPE = "tokenType";
-    private static final String LOGIN_SESSION_TOKEN_TYPE = "LOGIN_SESSION";
-
     @Value("${jwt.access-secret}")
     private String accessSecret;
 
@@ -29,9 +26,6 @@ public class JwtTokenProvider {
 
     @Value("${jwt.refresh-expiration}")
     private long refreshExpiration;
-
-    @Value("${jwt.login-session-expiration:300000}")
-    private long loginSessionExpiration;
 
     private SecretKey accessKey;
     private SecretKey refreshKey;
@@ -63,17 +57,6 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String createLoginSessionToken(Long memberId) {
-        Date now = new Date();
-        return Jwts.builder()
-                .subject(String.valueOf(memberId))
-                .claim(TOKEN_TYPE, LOGIN_SESSION_TOKEN_TYPE)
-                .issuedAt(now)
-                .expiration(new Date(now.getTime() + loginSessionExpiration))
-                .signWith(accessKey)
-                .compact();
-    }
-
     // AccessToken에서 memberId 추출 (Filter에서 사용)
     public Long getMemberId(String token) {
         return Long.parseLong(getAccessClaims(token).getSubject());
@@ -82,10 +65,6 @@ public class JwtTokenProvider {
     // RefreshToken에서 memberId 추출 (재발급 시 사용)
     public Long getMemberIdFromRefresh(String token) {
         return Long.parseLong(getRefreshClaims(token).getSubject());
-    }
-
-    public Long getMemberIdFromLoginSession(String token) {
-        return Long.parseLong(getLoginSessionClaims(token).getSubject());
     }
 
     public LoginMode getLoginMode(String token) {
@@ -104,13 +83,5 @@ public class JwtTokenProvider {
     private Claims getRefreshClaims(String token) {
         return Jwts.parser().verifyWith(refreshKey).build()
                 .parseSignedClaims(token).getPayload();
-    }
-
-    private Claims getLoginSessionClaims(String token) {
-        Claims claims = getAccessClaims(token);
-        if (!LOGIN_SESSION_TOKEN_TYPE.equals(claims.get(TOKEN_TYPE, String.class))) {
-            throw new IllegalArgumentException("유효하지 않은 로그인 세션 토큰입니다.");
-        }
-        return claims;
     }
 }

--- a/src/main/java/com/ssu/ongi/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/ssu/ongi/common/jwt/JwtTokenProvider.java
@@ -89,7 +89,11 @@ public class JwtTokenProvider {
     }
 
     public LoginMode getLoginMode(String token) {
-        return LoginMode.valueOf(getAccessClaims(token).get("loginMode", String.class));
+        String loginMode = getAccessClaims(token).get("loginMode", String.class);
+        if (loginMode == null) {
+            throw new IllegalArgumentException("loginMode claim이 없습니다.");
+        }
+        return LoginMode.valueOf(loginMode);
     }
 
     private Claims getAccessClaims(String token) {

--- a/src/main/java/com/ssu/ongi/common/jwt/TokenCommandService.java
+++ b/src/main/java/com/ssu/ongi/common/jwt/TokenCommandService.java
@@ -3,8 +3,6 @@ package com.ssu.ongi.common.jwt;
 import com.ssu.ongi.common.exception.GeneralException;
 import com.ssu.ongi.common.status.ErrorStatus;
 import com.ssu.ongi.domain.member.enums.LoginMode;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,20 +15,6 @@ public class TokenCommandService {
 
     public Long getMemberIdFromRefreshToken(String refreshToken) {
         return jwtTokenProvider.getMemberIdFromRefresh(refreshToken);
-    }
-
-    public String issueLoginSessionToken(Long memberId) {
-        return jwtTokenProvider.createLoginSessionToken(memberId);
-    }
-
-    public Long getMemberIdFromLoginSessionToken(String loginSessionToken) {
-        try {
-            return jwtTokenProvider.getMemberIdFromLoginSession(loginSessionToken);
-        } catch (ExpiredJwtException e) {
-            throw new GeneralException(ErrorStatus.JWT_EXPIRED);
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new GeneralException(ErrorStatus.JWT_INVALID);
-        }
     }
 
     // 로그인 시 호출 - 검증 없이 바로 발급 (기존 토큰 무효화 후 신규 발급)

--- a/src/main/java/com/ssu/ongi/common/jwt/TokenCommandService.java
+++ b/src/main/java/com/ssu/ongi/common/jwt/TokenCommandService.java
@@ -3,6 +3,8 @@ package com.ssu.ongi.common.jwt;
 import com.ssu.ongi.common.exception.GeneralException;
 import com.ssu.ongi.common.status.ErrorStatus;
 import com.ssu.ongi.domain.member.enums.LoginMode;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +17,20 @@ public class TokenCommandService {
 
     public Long getMemberIdFromRefreshToken(String refreshToken) {
         return jwtTokenProvider.getMemberIdFromRefresh(refreshToken);
+    }
+
+    public String issueLoginSessionToken(Long memberId) {
+        return jwtTokenProvider.createLoginSessionToken(memberId);
+    }
+
+    public Long getMemberIdFromLoginSessionToken(String loginSessionToken) {
+        try {
+            return jwtTokenProvider.getMemberIdFromLoginSession(loginSessionToken);
+        } catch (ExpiredJwtException e) {
+            throw new GeneralException(ErrorStatus.JWT_EXPIRED);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new GeneralException(ErrorStatus.JWT_INVALID);
+        }
     }
 
     // 로그인 시 호출 - 검증 없이 바로 발급 (기존 토큰 무효화 후 신규 발급)

--- a/src/main/java/com/ssu/ongi/common/status/ErrorStatus.java
+++ b/src/main/java/com/ssu/ongi/common/status/ErrorStatus.java
@@ -26,6 +26,7 @@ public enum ErrorStatus implements BaseStatus {
      */
     DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "AUTH_409", "이미 사용 중인 아이디입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_401", "아이디 또는 비밀번호가 올바르지 않습니다."),
+    LOGIN_SESSION_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_401", "로그인 세션이 만료되었습니다. 다시 로그인해주세요."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_404", "회원을 찾을 수 없습니다."),
     ELDER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_404", "어르신 정보를 찾을 수 없습니다."),
     ELDER_CANNOT_LOGOUT(HttpStatus.FORBIDDEN, "AUTH_403", "어르신 모드에서는 로그아웃이 불가능합니다."),

--- a/src/main/java/com/ssu/ongi/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.ssu.ongi.domain.auth.controller;
 
 import com.ssu.ongi.domain.auth.controller.docs.AuthControllerDocs;
+import com.ssu.ongi.domain.auth.dto.response.LoginStartResponse;
 import com.ssu.ongi.domain.auth.dto.response.ReissueResponse;
 import com.ssu.ongi.common.response.ApiResponse;
 import com.ssu.ongi.common.status.SuccessStatus;
@@ -10,6 +11,7 @@ import com.ssu.ongi.domain.auth.service.AuthCommandService;
 import com.ssu.ongi.domain.auth.service.PhoneVerificationService;
 import com.ssu.ongi.domain.auth.service.AuthQueryService;
 import com.ssu.ongi.domain.member.dto.request.FindIdRequest;
+import com.ssu.ongi.domain.member.dto.request.LoginModeRequest;
 import com.ssu.ongi.domain.member.dto.request.LoginRequest;
 import com.ssu.ongi.domain.member.dto.request.ReissueRequest;
 import com.ssu.ongi.domain.member.dto.request.SignupRequest;
@@ -60,10 +62,19 @@ public class AuthController implements AuthControllerDocs {
 
     @Override
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(
+    public ResponseEntity<ApiResponse<LoginStartResponse>> login(
             @Valid @RequestBody LoginRequest request
     ) {
-        LoginResponse response = authCommandService.login(request);
+        LoginStartResponse response = authCommandService.login(request);
+        return ApiResponse.success(SuccessStatus.LOGIN_SUCCESS, response);
+    }
+
+    @Override
+    @PostMapping("/login/mode")
+    public ResponseEntity<ApiResponse<LoginResponse>> selectLoginMode(
+            @Valid @RequestBody LoginModeRequest request
+    ) {
+        LoginResponse response = authCommandService.selectLoginMode(request);
         return ApiResponse.success(SuccessStatus.LOGIN_SUCCESS, response);
     }
 

--- a/src/main/java/com/ssu/ongi/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/controller/docs/AuthControllerDocs.java
@@ -211,13 +211,13 @@ public interface AuthControllerDocs {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "401",
-                    description = "로그인 세션 토큰 만료 또는 유효하지 않은 토큰",
+                    description = "로그인 세션 만료 또는 존재하지 않음",
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": false,
-                                      "code": "JWT_401",
-                                      "message": "유효하지 않은 토큰입니다."
+                                      "code": "AUTH_401",
+                                      "message": "로그인 세션이 만료되었습니다. 다시 로그인해주세요."
                                     }
                                     """))
             ),

--- a/src/main/java/com/ssu/ongi/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/controller/docs/AuthControllerDocs.java
@@ -157,8 +157,8 @@ public interface AuthControllerDocs {
 
     @Operation(summary = "로그인 2단계 - 역할 선택", description = """
             로그인 세션 토큰과 선택한 모드로 실제 JWT를 발급합니다.
-            - GUARDIAN 모드: 보호자 정보 + 등록된 모든 어르신 목록 반환
-            - ELDER 모드: 첫 번째 어르신 정보만 반환
+            - GUARDIAN 모드: 보호자 정보 + 어르신 정보 반환
+            - ELDER 모드: 어르신 정보 반환
             """)
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -177,7 +177,7 @@ public interface AuthControllerDocs {
                                                 "refreshToken": "eyJhbGciOiJIUzI1NiJ9...",
                                                 "loginMode": "GUARDIAN",
                                                 "member": { "memberId": 1, "name": "홍길동", "phone": "010-1234-5678" },
-                                                "elders": [{ "elderId": 1, "name": "홍부모", "age": 75, "relationship": "부모" }]
+                                                "elder": { "elderId": 1, "name": "홍부모", "age": 75, "relationship": "부모" }
                                               }
                                             }
                                             """),

--- a/src/main/java/com/ssu/ongi/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/controller/docs/AuthControllerDocs.java
@@ -122,7 +122,7 @@ public interface AuthControllerDocs {
                                       "code": "AUTH_200",
                                       "message": "로그인에 성공하였습니다.",
                                       "data": {
-                                        "loginSessionToken": "eyJhbGciOiJIUzI1NiJ9..."
+                                        "loginSessionToken": "550e8400-e29b-41d4-a716-446655440000"
                                       }
                                     }
                                     """))

--- a/src/main/java/com/ssu/ongi/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/controller/docs/AuthControllerDocs.java
@@ -157,6 +157,7 @@ public interface AuthControllerDocs {
 
     @Operation(summary = "로그인 2단계 - 역할 선택", description = """
             로그인 세션 토큰과 선택한 모드로 실제 JWT를 발급합니다.
+            현재 정책상 보호자 계정당 어르신은 1명이며, 응답도 elder 단일 객체로 반환합니다.
             - GUARDIAN 모드: 보호자 정보 + 어르신 정보 반환
             - ELDER 모드: 어르신 정보 반환
             """)

--- a/src/main/java/com/ssu/ongi/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/controller/docs/AuthControllerDocs.java
@@ -109,8 +109,54 @@ public interface AuthControllerDocs {
     );
 
 
-    @Operation(summary = "로그인", description = """
-            아이디/비밀번호로 로그인하고 모드를 선택합니다.
+    @Operation(summary = "로그인 1단계", description = "아이디/비밀번호를 검증하고 역할 선택에 사용할 로그인 세션 토큰을 발급합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 정보 검증 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = LoginStartResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "AUTH_200",
+                                      "message": "로그인에 성공하였습니다.",
+                                      "data": {
+                                        "loginSessionToken": "eyJhbGciOiJIUzI1NiJ9..."
+                                      }
+                                    }
+                                    """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "유효성 검사 실패 (아이디/비밀번호 누락)",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON_400",
+                                      "message": "아이디를 입력해주세요."
+                                    }
+                                    """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "아이디 또는 비밀번호 불일치",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH_401",
+                                      "message": "아이디 또는 비밀번호가 올바르지 않습니다."
+                                    }
+                                    """))
+            )
+    })
+    ResponseEntity<ApiResponse<LoginStartResponse>> login(@Valid @RequestBody LoginRequest request);
+
+
+    @Operation(summary = "로그인 2단계 - 역할 선택", description = """
+            로그인 세션 토큰과 선택한 모드로 실제 JWT를 발급합니다.
             - GUARDIAN 모드: 보호자 정보 + 등록된 모든 어르신 목록 반환
             - ELDER 모드: 첫 번째 어르신 정보만 반환
             """)
@@ -128,6 +174,7 @@ public interface AuthControllerDocs {
                                               "message": "로그인에 성공하였습니다.",
                                               "data": {
                                                 "accessToken": "eyJhbGciOiJIUzI1NiJ9...",
+                                                "refreshToken": "eyJhbGciOiJIUzI1NiJ9...",
                                                 "loginMode": "GUARDIAN",
                                                 "member": { "memberId": 1, "name": "홍길동", "phone": "010-1234-5678" },
                                                 "elders": [{ "elderId": 1, "name": "홍부모", "age": 75, "relationship": "부모" }]
@@ -141,6 +188,7 @@ public interface AuthControllerDocs {
                                               "message": "로그인에 성공하였습니다.",
                                               "data": {
                                                 "accessToken": "eyJhbGciOiJIUzI1NiJ9...",
+                                                "refreshToken": "eyJhbGciOiJIUzI1NiJ9...",
                                                 "loginMode": "ELDER",
                                                 "elder": { "elderId": 1, "name": "홍부모", "age": 75, "relationship": "부모" }
                                               }
@@ -150,7 +198,7 @@ public interface AuthControllerDocs {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
-                    description = "유효성 검사 실패 (아이디/비밀번호/로그인 모드 누락)",
+                    description = "유효성 검사 실패 (로그인 세션 토큰/로그인 모드/FCM 토큰/OS 타입 누락)",
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(value = """
                                     {
@@ -162,31 +210,29 @@ public interface AuthControllerDocs {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "401",
-                    description = "아이디 또는 비밀번호 불일치",
+                    description = "로그인 세션 토큰 만료 또는 유효하지 않은 토큰",
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": false,
-                                      "code": "AUTH_401",
-                                      "message": "아이디 또는 비밀번호가 올바르지 않습니다."
+                                      "code": "JWT_401",
+                                      "message": "유효하지 않은 토큰입니다."
                                     }
                                     """))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
-                    description = "어르신 정보 없음",
+                    description = "회원 또는 어르신 정보 없음",
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": false,
-                                      "code": "AUTH_404_2",
+                                      "code": "AUTH_404",
                                       "message": "어르신 정보를 찾을 수 없습니다."
                                     }
                                     """))
             )
     })
-    ResponseEntity<ApiResponse<LoginStartResponse>> login(@Valid @RequestBody LoginRequest request);
-
     ResponseEntity<ApiResponse<LoginResponse>> selectLoginMode(@Valid @RequestBody LoginModeRequest request);
 
 

--- a/src/main/java/com/ssu/ongi/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/controller/docs/AuthControllerDocs.java
@@ -1,10 +1,12 @@
 package com.ssu.ongi.domain.auth.controller.docs;
 
-import com.ssu.ongi.domain.auth.dto.response.ReissueResponse;
 import com.ssu.ongi.common.response.ApiResponse;
 import com.ssu.ongi.domain.auth.dto.request.SendVerificationRequest;
 import com.ssu.ongi.domain.auth.dto.request.VerifyCodeRequest;
+import com.ssu.ongi.domain.auth.dto.response.LoginStartResponse;
+import com.ssu.ongi.domain.auth.dto.response.ReissueResponse;
 import com.ssu.ongi.domain.member.dto.request.FindIdRequest;
+import com.ssu.ongi.domain.member.dto.request.LoginModeRequest;
 import com.ssu.ongi.domain.member.dto.request.LoginRequest;
 import com.ssu.ongi.domain.member.dto.request.ReissueRequest;
 import com.ssu.ongi.domain.member.dto.request.SignupRequest;
@@ -183,7 +185,9 @@ public interface AuthControllerDocs {
                                     """))
             )
     })
-    ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request);
+    ResponseEntity<ApiResponse<LoginStartResponse>> login(@Valid @RequestBody LoginRequest request);
+
+    ResponseEntity<ApiResponse<LoginResponse>> selectLoginMode(@Valid @RequestBody LoginModeRequest request);
 
 
     @Operation(summary = "로그아웃", description = "RefreshToken을 폐기하고 FCM 토큰을 삭제합니다.")

--- a/src/main/java/com/ssu/ongi/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/dto/response/LoginResponse.java
@@ -7,32 +7,30 @@ import com.ssu.ongi.domain.member.dto.response.MemberResponse;
 import com.ssu.ongi.domain.member.entity.Member;
 import com.ssu.ongi.domain.member.enums.LoginMode;
 
-import java.util.List;
-
 public record LoginResponse(
         String accessToken,
         String refreshToken,
         LoginMode loginMode,
         MemberResponse member,
-        List<ElderResponse> elders,
         ElderResponse elder
 ) {
     public static LoginResponse of(String accessToken, String refreshToken, LoginMode loginMode, Member member) {
+        ElderResponse elder = member.getElders().stream()
+                .findFirst()
+                .map(ElderResponse::from)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ELDER_NOT_FOUND));
+
         if (loginMode == LoginMode.GUARDIAN) {
             return new LoginResponse(
                     accessToken, refreshToken, LoginMode.GUARDIAN,
                     MemberResponse.from(member),
-                    member.getElders().stream().map(ElderResponse::from).toList(),
-                    null
+                    elder
             );
         } else {
             return new LoginResponse(
                     accessToken, refreshToken, LoginMode.ELDER,
-                    null, null,
-                    member.getElders().stream()
-                            .findFirst()
-                            .map(ElderResponse::from)
-                            .orElseThrow(() -> new GeneralException(ErrorStatus.ELDER_NOT_FOUND))
+                    null,
+                    elder
             );
         }
     }

--- a/src/main/java/com/ssu/ongi/domain/auth/dto/response/LoginStartResponse.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/dto/response/LoginStartResponse.java
@@ -1,0 +1,9 @@
+package com.ssu.ongi.domain.auth.dto.response;
+
+public record LoginStartResponse(
+        String loginSessionToken
+) {
+    public static LoginStartResponse from(String loginSessionToken) {
+        return new LoginStartResponse(loginSessionToken);
+    }
+}

--- a/src/main/java/com/ssu/ongi/domain/auth/repository/LoginSessionRepository.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/repository/LoginSessionRepository.java
@@ -1,0 +1,31 @@
+package com.ssu.ongi.domain.auth.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class LoginSessionRepository {
+
+    private static final String PREFIX = "login-session:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${auth.login-session-expiration:300000}")
+    private long loginSessionExpiration;
+
+    public void save(String loginSessionToken, Long memberId) {
+        redisTemplate.opsForValue()
+                .set(PREFIX + loginSessionToken, String.valueOf(memberId), loginSessionExpiration, TimeUnit.MILLISECONDS);
+    }
+
+    public Optional<Long> consume(String loginSessionToken) {
+        return Optional.ofNullable(redisTemplate.opsForValue().getAndDelete(PREFIX + loginSessionToken))
+                .map(Long::valueOf);
+    }
+}

--- a/src/main/java/com/ssu/ongi/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/service/AuthCommandService.java
@@ -4,9 +4,11 @@ import com.ssu.ongi.common.exception.GeneralException;
 import com.ssu.ongi.common.jwt.TokenCommandService;
 import com.ssu.ongi.common.jwt.TokenPair;
 import com.ssu.ongi.common.status.ErrorStatus;
+import com.ssu.ongi.domain.auth.dto.response.LoginStartResponse;
 import com.ssu.ongi.domain.auth.dto.response.ReissueResponse;
 import com.ssu.ongi.domain.elder.entity.Elder;
 import com.ssu.ongi.domain.elder.service.ElderCommandService;
+import com.ssu.ongi.domain.member.dto.request.LoginModeRequest;
 import com.ssu.ongi.domain.member.dto.request.LoginRequest;
 import com.ssu.ongi.domain.member.dto.request.ReissueRequest;
 import com.ssu.ongi.domain.member.dto.request.SignupRequest;
@@ -40,9 +42,17 @@ public class AuthCommandService {
         memberCommandService.saveMember(member);
     }
 
-    public LoginResponse login(LoginRequest request) {
+    public LoginStartResponse login(LoginRequest request) {
         Member member = memberQueryService.findByLoginIdWithElders(request.loginId());
         memberQueryService.validatePassword(member, request.password());
+
+        String loginSessionToken = tokenCommandService.issueLoginSessionToken(member.getId());
+        return LoginStartResponse.from(loginSessionToken);
+    }
+
+    public LoginResponse selectLoginMode(LoginModeRequest request) {
+        Long memberId = tokenCommandService.getMemberIdFromLoginSessionToken(request.loginSessionToken());
+        Member member = memberQueryService.findByIdWithElders(memberId);
 
         if (request.loginMode() == LoginMode.GUARDIAN) {
             memberCommandService.updateFcmToken(member, request.fcmToken(), request.osType());

--- a/src/main/java/com/ssu/ongi/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/service/AuthCommandService.java
@@ -20,6 +20,7 @@ import com.ssu.ongi.domain.member.enums.LoginMode;
 import com.ssu.ongi.domain.member.service.MemberCommandService;
 import com.ssu.ongi.domain.member.service.MemberQueryService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,7 @@ import java.util.UUID;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class AuthCommandService {
 
     private final MemberCommandService memberCommandService;
@@ -58,19 +60,25 @@ public class AuthCommandService {
     public LoginResponse selectLoginMode(LoginModeRequest request) {
         Long memberId = loginSessionRepository.consume(request.loginSessionToken())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_SESSION_EXPIRED));
-        Member member = memberQueryService.findByIdWithElders(memberId);
 
-        if (request.loginMode() == LoginMode.GUARDIAN) {
-            memberCommandService.updateFcmToken(member, request.fcmToken(), request.osType());
-        } else {
-            Elder elder = member.getElders().stream()
-                    .findFirst()
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.ELDER_NOT_FOUND));
-            elderCommandService.updateFcmToken(elder, request.fcmToken(),request.osType());
+        try {
+            Member member = memberQueryService.findByIdWithElders(memberId);
+
+            if (request.loginMode() == LoginMode.GUARDIAN) {
+                memberCommandService.updateFcmToken(member, request.fcmToken(), request.osType());
+            } else {
+                Elder elder = member.getElders().stream()
+                        .findFirst()
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.ELDER_NOT_FOUND));
+                elderCommandService.updateFcmToken(elder, request.fcmToken(),request.osType());
+            }
+
+            TokenPair tokens = tokenCommandService.issueTokens(member.getId(), request.loginMode());
+            return LoginResponse.of(tokens.accessToken(), tokens.refreshToken(), request.loginMode(), member);
+        } catch (RuntimeException e) {
+            log.warn("로그인 세션 소비 후 로그인 모드 선택 처리 실패: memberId={}, loginMode={}", memberId, request.loginMode(), e);
+            throw e;
         }
-
-        TokenPair tokens = tokenCommandService.issueTokens(member.getId(), request.loginMode());
-        return LoginResponse.of(tokens.accessToken(), tokens.refreshToken(), request.loginMode(), member);
     }
 
     public void logout(Long memberId, LoginMode loginMode) {

--- a/src/main/java/com/ssu/ongi/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/service/AuthCommandService.java
@@ -6,6 +6,7 @@ import com.ssu.ongi.common.jwt.TokenPair;
 import com.ssu.ongi.common.status.ErrorStatus;
 import com.ssu.ongi.domain.auth.dto.response.LoginStartResponse;
 import com.ssu.ongi.domain.auth.dto.response.ReissueResponse;
+import com.ssu.ongi.domain.auth.repository.LoginSessionRepository;
 import com.ssu.ongi.domain.elder.entity.Elder;
 import com.ssu.ongi.domain.elder.service.ElderCommandService;
 import com.ssu.ongi.domain.member.dto.request.LoginModeRequest;
@@ -22,6 +23,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -32,6 +35,7 @@ public class AuthCommandService {
     private final ElderCommandService elderCommandService;
     private final TokenCommandService tokenCommandService;
     private final PhoneVerificationService phoneVerificationService;
+    private final LoginSessionRepository loginSessionRepository;
 
     public void signup(SignupRequest request) {
         phoneVerificationService.validateVerified(request.phone());
@@ -46,12 +50,14 @@ public class AuthCommandService {
         Member member = memberQueryService.findByLoginIdWithElders(request.loginId());
         memberQueryService.validatePassword(member, request.password());
 
-        String loginSessionToken = tokenCommandService.issueLoginSessionToken(member.getId());
+        String loginSessionToken = UUID.randomUUID().toString();
+        loginSessionRepository.save(loginSessionToken, member.getId());
         return LoginStartResponse.from(loginSessionToken);
     }
 
     public LoginResponse selectLoginMode(LoginModeRequest request) {
-        Long memberId = tokenCommandService.getMemberIdFromLoginSessionToken(request.loginSessionToken());
+        Long memberId = loginSessionRepository.consume(request.loginSessionToken())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.JWT_INVALID));
         Member member = memberQueryService.findByIdWithElders(memberId);
 
         if (request.loginMode() == LoginMode.GUARDIAN) {

--- a/src/main/java/com/ssu/ongi/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/service/AuthCommandService.java
@@ -57,7 +57,7 @@ public class AuthCommandService {
 
     public LoginResponse selectLoginMode(LoginModeRequest request) {
         Long memberId = loginSessionRepository.consume(request.loginSessionToken())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.JWT_INVALID));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_SESSION_EXPIRED));
         Member member = memberQueryService.findByIdWithElders(memberId);
 
         if (request.loginMode() == LoginMode.GUARDIAN) {

--- a/src/main/java/com/ssu/ongi/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/ssu/ongi/domain/auth/service/AuthCommandService.java
@@ -48,6 +48,7 @@ public class AuthCommandService {
         memberCommandService.saveMember(member);
     }
 
+    @Transactional(readOnly = true)
     public LoginStartResponse login(LoginRequest request) {
         Member member = memberQueryService.findByLoginIdWithElders(request.loginId());
         memberQueryService.validatePassword(member, request.password());

--- a/src/main/java/com/ssu/ongi/domain/member/dto/request/LoginModeRequest.java
+++ b/src/main/java/com/ssu/ongi/domain/member/dto/request/LoginModeRequest.java
@@ -1,0 +1,23 @@
+package com.ssu.ongi.domain.member.dto.request;
+
+import com.ssu.ongi.domain.member.enums.LoginMode;
+import com.ssu.ongi.domain.member.enums.OsType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record LoginModeRequest(
+        @NotBlank(message = "로그인 세션 토큰을 입력해주세요.")
+        String loginSessionToken,
+
+        @NotNull(message = "로그인 모드를 선택해주세요.")
+        LoginMode loginMode,
+
+        @NotBlank(message = "fcm_token을 입력해주세요.")
+        @Size(max = 512, message = "fcm_token은 512자 이하여야 합니다.")
+        String fcmToken,
+
+        @NotNull(message = "OS 타입을 입력해주세요.")
+        OsType osType
+) {
+}

--- a/src/main/java/com/ssu/ongi/domain/member/dto/request/LoginRequest.java
+++ b/src/main/java/com/ssu/ongi/domain/member/dto/request/LoginRequest.java
@@ -1,26 +1,12 @@
 package com.ssu.ongi.domain.member.dto.request;
 
-import com.ssu.ongi.domain.member.enums.LoginMode;
-import com.ssu.ongi.domain.member.enums.OsType;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 public record LoginRequest(
         @NotBlank(message = "아이디를 입력해주세요.")
         String loginId,
 
         @NotBlank(message = "비밀번호를 입력해주세요.")
-        String password,
-
-        @NotNull(message = "로그인 모드를 선택해주세요.")
-        LoginMode loginMode,
-
-        @NotBlank(message = "fcm_token을 입력해주세요.")
-        @Size(max = 512, message = "fcm_token은 512자 이하여야 합니다.")
-        String fcmToken,
-
-        @NotNull(message = "OS 타입을 입력해주세요.")
-        OsType osType
+        String password
 ) {
 }

--- a/src/main/java/com/ssu/ongi/domain/member/repository/MemberQueryRepository.java
+++ b/src/main/java/com/ssu/ongi/domain/member/repository/MemberQueryRepository.java
@@ -12,6 +12,9 @@ public interface MemberQueryRepository extends Repository<Member, Long> {
     @Query("SELECT m FROM Member m JOIN FETCH m.elders WHERE m.loginId = :loginId")
     Optional<Member> findByLoginIdWithElders(@Param("loginId") String loginId);
 
+    @Query("SELECT m FROM Member m JOIN FETCH m.elders WHERE m.id = :id")
+    Optional<Member> findByIdWithElders(@Param("id") Long id);
+
     Optional<Member> findByLoginId(String loginId);
 
     Optional<Member> findById(Long id);

--- a/src/main/java/com/ssu/ongi/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/ssu/ongi/domain/member/service/MemberQueryService.java
@@ -22,6 +22,11 @@ public class MemberQueryService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
     }
 
+    public Member findByIdWithElders(Long memberId) {
+        return memberQueryRepository.findByIdWithElders(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
     // 로그인 전용 - elders JOIN FETCH로 N+1 방지
     public Member findByLoginIdWithElders(String loginId) {
         return memberQueryRepository.findByLoginIdWithElders(loginId)


### PR DESCRIPTION
## #️⃣ 관련 이슈
  closed #29

  로그인 과정에서 아이디/비밀번호 검증 이후 사용자 역할을 선택하도록 2단계 로그인 흐름으로 변경
  또한 로그인 세션을 Redis 기반 단일 사용 토큰으로 관리해 JWT access token과의 혼선을 제거하고, 세션 만료 전용 에러를 추가

  ## PR 유형
  어떤 변경 사항이 있나요?

  - [x] 새로운 기능 추가
  - [x] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 주석 추가 및 수정
  - [x] 문서 수정
  - [ ] 테스트 추가, 테스트 리팩토링
  - [ ] 빌드 부분 혹은 패키지 매니저 수정
  - [ ] 파일 혹은 폴더명 수정
  - [ ] 파일 혹은 폴더 삭제

  ## PR Checklist
  PR이 다음 요구 사항을 충족하는지 확인하세요.

  - [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  - [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

  ## 🧩 작업 내용

  - 로그인 API를 2단계 흐름으로 분리
    - `POST /api/auth/login`: 아이디/비밀번호 검증 후 `loginSessionToken` 발급
    - `POST /api/auth/login/mode`: 역할 선택 후 실제 `accessToken`, `refreshToken` 발급

  - `loginSessionToken`을 JWT가 아닌 Redis UUID 방식으로 변경
    - access token과 같은 key를 공유하지 않도록 수정
    - `getAndDelete` 방식으로 로그인 세션 단일 사용 보장
    - 기본 TTL은 5분

  - 로그인 세션 만료 전용 에러를 추가
    - 기존 `JWT_INVALID` 대신 `LOGIN_SESSION_EXPIRED` 사용
    - 메시지: `로그인 세션이 만료되었습니다. 다시 로그인해주세요.`

  - 로그인 응답에서 `elders` 리스트를 제거하고 `elder` 단일 객체만 반환
    - 현재 정책상 보호자 1명당 어르신 1명 기준

  - `loginMode` claim 없는 토큰이 Bearer로 들어왔을 때 500이 발생하지 않도록 방어 로직을 추가

  - 로그인 세션 consume 이후 DB/FCM 처리 실패 시 추적 가능한 로그를 추가

  - 로그인 1단계 메서드에 `@Transactional(readOnly = true)`를 적용

  - Swagger 문서와 README 설정 문서를 갱신


  ## 📸 스크린샷(선택)

  Swagger 변경 사항은 API 문서에서 확인 가능합니다.

  📣 **To Reviewers**