### PR TITLE
[Feat] Flyway 초기 마이그레이션 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Security

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,11 @@ spring:
     serialization:
       write-dates-as-timestamps: false
 
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 1
+
 springdoc:
   swagger-ui:
     tags-sorter: alpha

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,123 @@
+CREATE TABLE member
+(
+    member_id  BIGINT AUTO_INCREMENT
+        PRIMARY KEY,
+    login_id   VARCHAR(255)            NOT NULL,
+    name       VARCHAR(255)            NOT NULL,
+    password   VARCHAR(255)            NOT NULL,
+    phone      VARCHAR(255)            NOT NULL,
+    created_at DATETIME(6)             NOT NULL,
+    updated_at DATETIME(6)             NOT NULL,
+    fcm_token  VARCHAR(512)            NULL,
+    os_type    ENUM ('IOS', 'ANDROID') NULL,
+    deleted_at DATETIME(6)             NULL,
+    CONSTRAINT UK_7r9uk13t9mp7py0w0jh3j05oh
+        UNIQUE (fcm_token, os_type),
+    CONSTRAINT UK_enfm5patwjqulw8k4wwuo6f60
+        UNIQUE (login_id)
+);
+
+CREATE TABLE elder
+(
+    elder_id     BIGINT AUTO_INCREMENT
+        PRIMARY KEY,
+    member_id    BIGINT                  NOT NULL,
+    age          INT                     NOT NULL,
+    name         VARCHAR(255)            NOT NULL,
+    relationship VARCHAR(255)            NOT NULL,
+    created_at   DATETIME(6)             NOT NULL,
+    updated_at   DATETIME(6)             NOT NULL,
+    fcm_token    VARCHAR(512)            NULL,
+    os_type      ENUM ('IOS', 'ANDROID') NULL,
+    phone        VARCHAR(255)            NULL,
+    CONSTRAINT fcm_token_unique
+        UNIQUE (os_type, fcm_token),
+    CONSTRAINT fk_elder_member
+        FOREIGN KEY (member_id) REFERENCES member (member_id)
+            ON DELETE CASCADE
+);
+
+CREATE TABLE device
+(
+    device_id     BIGINT AUTO_INCREMENT
+        PRIMARY KEY,
+    created_at    DATETIME(6)     NOT NULL,
+    updated_at    DATETIME(6)     NOT NULL,
+    serial_number VARCHAR(255)    NOT NULL,
+    elder_id      BIGINT          NOT NULL,
+    status        ENUM ('ONLINE') NULL,
+    uptime_sec    BIGINT          NULL,
+    rssi          INT             NULL,
+    last_seen_at  DATETIME(6)     NULL,
+    device_token  VARCHAR(255)    NOT NULL,
+    CONSTRAINT UK_cvkr0tbgtxuyuyjv6byef3dj0
+        UNIQUE (device_token),
+    CONSTRAINT device_pk
+        UNIQUE (elder_id),
+    CONSTRAINT device_pk_2
+        UNIQUE (serial_number),
+    CONSTRAINT FKksmyogk6rhkqu1l3b5ejnojll
+        FOREIGN KEY (elder_id) REFERENCES elder (elder_id)
+);
+
+CREATE TABLE medicine
+(
+    medicine_id    BIGINT AUTO_INCREMENT
+        PRIMARY KEY,
+    elder_id       BIGINT       NOT NULL,
+    name           VARCHAR(255) NOT NULL,
+    created_at     DATETIME(6)  NOT NULL,
+    updated_at     DATETIME(6)  NOT NULL,
+    scheduled_time TIME(6)      NOT NULL,
+    CONSTRAINT FK15fb53abaxyr2jf2tg72nthxq
+        FOREIGN KEY (elder_id) REFERENCES elder (elder_id)
+);
+
+CREATE TABLE device_slot
+(
+    device_slot_id BIGINT AUTO_INCREMENT
+        PRIMARY KEY,
+    created_at     DATETIME(6)              NOT NULL,
+    updated_at     DATETIME(6)              NOT NULL,
+    slot_number    INT                      NOT NULL,
+    device_id      BIGINT                   NOT NULL,
+    elder_id       BIGINT                   NOT NULL,
+    medicine_id    BIGINT                   NOT NULL,
+    status         ENUM ('TAKEN', 'MISSED') NULL,
+    CONSTRAINT FK7dhd2h5l4ie20s9pokbje4l4v
+        FOREIGN KEY (elder_id) REFERENCES elder (elder_id),
+    CONSTRAINT FK97rq4iig571nmvls7llm8ieik
+        FOREIGN KEY (device_id) REFERENCES device (device_id),
+    CONSTRAINT FK_device_slot_medicine
+        FOREIGN KEY (medicine_id) REFERENCES medicine (medicine_id)
+);
+
+CREATE TABLE medication_record
+(
+    medication_record_id BIGINT AUTO_INCREMENT
+        PRIMARY KEY,
+    recorded_at          DATETIME(6)              NOT NULL,
+    result               ENUM ('TAKEN', 'MISSED') NOT NULL,
+    device_id            BIGINT                   NOT NULL,
+    created_at           DATETIME(6)              NOT NULL,
+    updated_at           DATETIME(6)              NOT NULL,
+    medicine_id          BIGINT                   NOT NULL,
+    CONSTRAINT uk_medicine_recorded_at
+        UNIQUE (medicine_id, recorded_at),
+    CONSTRAINT FK_medication_record_medicine
+        FOREIGN KEY (medicine_id) REFERENCES medicine (medicine_id),
+    CONSTRAINT FKp2gt8s51ktxfbwehv1w2wlkrs
+        FOREIGN KEY (device_id) REFERENCES device (device_id)
+);
+
+CREATE TABLE medicine_schedule
+(
+    medicine_schedule_id BIGINT AUTO_INCREMENT
+        PRIMARY KEY,
+    created_at           DATETIME(6) NOT NULL,
+    updated_at           DATETIME(6) NOT NULL,
+    scheduled_time       TIME(6)     NOT NULL,
+    medicine_id          BIGINT      NOT NULL,
+    CONSTRAINT FK41jx8gfobll9d63qsvuuvwnrn
+        FOREIGN KEY (medicine_id) REFERENCES medicine (medicine_id)
+);


### PR DESCRIPTION
## #️⃣ 관련 이슈
  closed #44 

  현재 서버 DB 스키마를 Flyway V1 baseline으로 관리하기 위해 Flyway 의존성과 초기 마이그레이션 SQL을 추가

  ## PR 유형

  어떤 변경 사항이 있나요?

  - [x] 새로운 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 주석 추가 및 수정
  - [ ] 문서 수정
  - [ ] 테스트 추가, 테스트 리팩토링
  - [x] 빌드 부분 혹은 패키지 매니저 수정
  - [ ] 파일 혹은 폴더명 수정
  - [ ] 파일 혹은 폴더 삭제

  ## PR Checklist

  PR이 다음 요구 사항을 충족하는지 확인하세요.

  - [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  - [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

  ## 🧩 작업 내용

  - Flyway 의존성을 추가
      - flyway-core
      - flyway-mysql
  - src/main/resources/db/migration/V1__init_schema.sql을 추가
  - 현재 서버 DB DDL 기준으로 초기 스키마를 작성
  - 기존 서버 DB를 Flyway baseline으로 관리하기 위해 설정을 추가
      - baseline-on-migrate: true
      - baseline-version: 1

  검증:

  ./gradlew compileJava

  ## 📸 스크린샷(선택)


  📣 To Reviewers

  이번 PR은 현재 서버 DB 스키마를 Flyway V1 baseline으로 이력화하기 위한 작업으로

  따라서 V1__init_schema.sql은 현재 서버 DDL 기준으로 작성
  medicine_schedule 테이블, 기존 constraint 이름, FCM token unique 정책, device.status enum은 서버 스키마
  기준으로 유지

