### PR TITLE
[Feat] 디바이스 상태 조회 API 추가

### DIFF
--- a/src/main/java/com/ssu/ongi/common/status/SuccessStatus.java
+++ b/src/main/java/com/ssu/ongi/common/status/SuccessStatus.java
@@ -48,6 +48,7 @@ public enum SuccessStatus implements BaseStatus {
      */
     DEVICE_CONNECTION_SUCCESS(HttpStatus.OK, "DEVICE_200", "디바이스가 연결되었습니다."),
     DEVICE_REGISTER_SUCCESS(HttpStatus.CREATED, "DEVICE_201", "디바이스가 등록되었습니다."),
+    DEVICE_STATUS_GET_SUCCESS(HttpStatus.OK, "DEVICE_200", "디바이스 상태 조회에 성공했습니다."),
     DEVICE_OPEN_ALL_SUCCESS(HttpStatus.OK, "DEVICE_200", "전체 약통 열기 명령을 전달했습니다."),
     DEVICE_CLOSE_ALL_SUCCESS(HttpStatus.OK, "DEVICE_200", "전체 약통 닫기 명령을 전달했습니다."),
     MEDICATION_STATUS_UPDATE_SUCCESS(HttpStatus.OK, "DEVICE_200", "복약 상태가 업데이트되었습니다.");

--- a/src/main/java/com/ssu/ongi/domain/device/controller/DeviceController.java
+++ b/src/main/java/com/ssu/ongi/domain/device/controller/DeviceController.java
@@ -7,12 +7,15 @@ import com.ssu.ongi.domain.device.controller.docs.DeviceControllerDocs;
 import com.ssu.ongi.domain.device.dto.request.DeviceRegisterRequest;
 import com.ssu.ongi.domain.device.dto.request.HeartbeatRequest;
 import com.ssu.ongi.domain.device.dto.request.MedicationStatusRequest;
+import com.ssu.ongi.domain.device.dto.response.DeviceStatusResponse;
 import com.ssu.ongi.domain.device.dto.response.RegisterDeviceResponse;
 import com.ssu.ongi.domain.device.service.DeviceCommandService;
+import com.ssu.ongi.domain.device.service.DeviceQueryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class DeviceController implements DeviceControllerDocs {
 
     private final DeviceCommandService deviceCommandService;
+    private final DeviceQueryService deviceQueryService;
 
     @Override
     @PostMapping("")
@@ -34,6 +38,18 @@ public class DeviceController implements DeviceControllerDocs {
     ) {
         RegisterDeviceResponse response = deviceCommandService.registerDevice(principal.memberId(), principal.loginMode(), request);
         return ApiResponse.success(SuccessStatus.DEVICE_REGISTER_SUCCESS, response);
+    }
+
+    /**
+     * 로그인한 보호자의 어르신에게 등록된 디바이스 상태를 조회합니다.
+     */
+    @Override
+    @GetMapping("/status")
+    public ResponseEntity<ApiResponse<DeviceStatusResponse>> getDeviceStatus(
+            @AuthenticationPrincipal MemberPrincipal principal
+    ) {
+        DeviceStatusResponse response = deviceQueryService.getDeviceStatus(principal.memberId(), principal.loginMode());
+        return ApiResponse.success(SuccessStatus.DEVICE_STATUS_GET_SUCCESS, response);
     }
 
     @Override

--- a/src/main/java/com/ssu/ongi/domain/device/controller/docs/DeviceControllerDocs.java
+++ b/src/main/java/com/ssu/ongi/domain/device/controller/docs/DeviceControllerDocs.java
@@ -5,6 +5,7 @@ import com.ssu.ongi.common.response.ApiResponse;
 import com.ssu.ongi.domain.device.dto.request.DeviceRegisterRequest;
 import com.ssu.ongi.domain.device.dto.request.HeartbeatRequest;
 import com.ssu.ongi.domain.device.dto.request.MedicationStatusRequest;
+import com.ssu.ongi.domain.device.dto.response.DeviceStatusResponse;
 import com.ssu.ongi.domain.device.dto.response.RegisterDeviceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -40,6 +41,32 @@ public interface DeviceControllerDocs {
     ResponseEntity<ApiResponse<RegisterDeviceResponse>> registerDevice(
             @AuthenticationPrincipal MemberPrincipal principal,
             @Valid @RequestBody DeviceRegisterRequest request
+    );
+
+    @Operation(summary = "디바이스 상태 조회", description = "보호자가 어르신에게 등록된 디바이스의 현재 상태를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "디바이스 상태 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": true,
+                                        "code": "DEVICE_200",
+                                        "message": "디바이스 상태 조회에 성공했습니다.",
+                                        "data": {
+                                            "deviceId": 1,
+                                            "serialNumber": "ONGI-001",
+                                            "status": "ONLINE",
+                                            "lastSeenAt": "2026-05-28T14:30:00",
+                                            "rssi": -60,
+                                            "uptimeSec": 3600
+                                        }
+                                    }
+                                    """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "어르신 모드 접근 불가"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "등록된 디바이스 없음")
+    })
+    ResponseEntity<ApiResponse<DeviceStatusResponse>> getDeviceStatus(
+            @AuthenticationPrincipal MemberPrincipal principal
     );
 
     @Operation(summary = "디바이스 heartbeat", description = "디바이스의 연결 상태를 업데이트합니다.")

--- a/src/main/java/com/ssu/ongi/domain/device/controller/docs/DeviceControllerDocs.java
+++ b/src/main/java/com/ssu/ongi/domain/device/controller/docs/DeviceControllerDocs.java
@@ -47,7 +47,8 @@ public interface DeviceControllerDocs {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "디바이스 상태 조회 성공",
                     content = @Content(mediaType = "application/json",
-                            examples = @ExampleObject(value = """
+                            examples = {
+                                    @ExampleObject(name = "연결된 디바이스", value = """
                                     {
                                         "isSuccess": true,
                                         "code": "DEVICE_200",
@@ -61,7 +62,23 @@ public interface DeviceControllerDocs {
                                             "uptimeSec": 3600
                                         }
                                     }
-                                    """))),
+                                    """),
+                                    @ExampleObject(name = "미연결 디바이스", value = """
+                                    {
+                                        "isSuccess": true,
+                                        "code": "DEVICE_200",
+                                        "message": "디바이스 상태 조회에 성공했습니다.",
+                                        "data": {
+                                            "deviceId": 1,
+                                            "serialNumber": "ONGI-001",
+                                            "status": null,
+                                            "lastSeenAt": null,
+                                            "rssi": null,
+                                            "uptimeSec": null
+                                        }
+                                    }
+                                    """)
+                            })),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "어르신 모드 접근 불가"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "등록된 디바이스 없음")
     })

--- a/src/main/java/com/ssu/ongi/domain/device/dto/response/DeviceStatusResponse.java
+++ b/src/main/java/com/ssu/ongi/domain/device/dto/response/DeviceStatusResponse.java
@@ -1,0 +1,29 @@
+package com.ssu.ongi.domain.device.dto.response;
+
+import com.ssu.ongi.domain.device.entity.Device;
+import com.ssu.ongi.domain.device.enums.DeviceStatus;
+
+import java.time.LocalDateTime;
+
+public record DeviceStatusResponse(
+        Long deviceId,
+        String serialNumber,
+        DeviceStatus status,
+        LocalDateTime lastSeenAt,
+        Integer rssi,
+        Long uptimeSec
+) {
+    /**
+     * 디바이스 엔티티를 상태 조회 응답으로 변환합니다.
+     */
+    public static DeviceStatusResponse from(Device device) {
+        return new DeviceStatusResponse(
+                device.getId(),
+                device.getSerialNumber(),
+                device.getStatus(),
+                device.getLastSeenAt(),
+                device.getRssi(),
+                device.getUptimeSec()
+        );
+    }
+}

--- a/src/main/java/com/ssu/ongi/domain/device/dto/response/DeviceStatusResponse.java
+++ b/src/main/java/com/ssu/ongi/domain/device/dto/response/DeviceStatusResponse.java
@@ -2,15 +2,22 @@ package com.ssu.ongi.domain.device.dto.response;
 
 import com.ssu.ongi.domain.device.entity.Device;
 import com.ssu.ongi.domain.device.enums.DeviceStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
 public record DeviceStatusResponse(
+        @Schema(description = "디바이스 ID")
         Long deviceId,
+        @Schema(description = "디바이스 시리얼 번호")
         String serialNumber,
+        @Schema(description = "디바이스 연결 상태. 최초 heartbeat 수신 전에는 null입니다.", nullable = true)
         DeviceStatus status,
+        @Schema(description = "마지막 heartbeat 수신 시각. 최초 heartbeat 수신 전에는 null입니다.", nullable = true)
         LocalDateTime lastSeenAt,
+        @Schema(description = "마지막 heartbeat RSSI 값. 최초 heartbeat 수신 전에는 null입니다.", nullable = true)
         Integer rssi,
+        @Schema(description = "마지막 heartbeat uptime 값. 최초 heartbeat 수신 전에는 null입니다.", nullable = true)
         Long uptimeSec
 ) {
     /**

--- a/src/main/java/com/ssu/ongi/domain/device/service/DeviceCommandService.java
+++ b/src/main/java/com/ssu/ongi/domain/device/service/DeviceCommandService.java
@@ -124,7 +124,7 @@ public class DeviceCommandService {
      * 보호자 모드 검증 후 어르신 정보를 반환합니다.
      */
     private Elder getGuardianElder(Long memberId, LoginMode loginMode) {
-        validateGuardianOnly(loginMode);
+        loginMode.validateGuardianOnly();
         return elderQueryService.getElderByMemberId(memberId);
     }
 
@@ -134,12 +134,4 @@ public class DeviceCommandService {
         }
     }
 
-    /**
-     * 어르신 모드인 경우 접근을 차단합니다.
-     */
-    private void validateGuardianOnly(LoginMode loginMode) {
-        if (loginMode == LoginMode.ELDER) {
-            throw new GeneralException(ErrorStatus.ELDER_CANNOT_ACCESS);
-        }
-    }
 }

--- a/src/main/java/com/ssu/ongi/domain/device/service/DeviceCommandService.java
+++ b/src/main/java/com/ssu/ongi/domain/device/service/DeviceCommandService.java
@@ -18,6 +18,7 @@ import com.ssu.ongi.domain.medicine.entity.MedicationRecord;
 import com.ssu.ongi.domain.medicine.enums.MedicationResult;
 import com.ssu.ongi.domain.medicine.service.MedicationRecordCommandService;
 import com.ssu.ongi.domain.member.enums.LoginMode;
+import com.ssu.ongi.domain.member.service.LoginModeValidator;
 import com.ssu.ongi.domain.notification.event.MedicationTakenEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,6 +44,7 @@ public class DeviceCommandService {
     private final DeviceSlotCommandService deviceSlotCommandService;
     private final MedicationRecordCommandService medicationRecordCommandService;
     private final ApplicationEventPublisher eventPublisher;
+    private final LoginModeValidator loginModeValidator;
 
     /**
      * 보호자의 어르신에게 디바이스를 등록하고 deviceToken을 발급합니다.
@@ -124,7 +126,7 @@ public class DeviceCommandService {
      * 보호자 모드 검증 후 어르신 정보를 반환합니다.
      */
     private Elder getGuardianElder(Long memberId, LoginMode loginMode) {
-        loginMode.validateGuardianOnly();
+        loginModeValidator.validateGuardianOnly(loginMode);
         return elderQueryService.getElderByMemberId(memberId);
     }
 

--- a/src/main/java/com/ssu/ongi/domain/device/service/DeviceQueryService.java
+++ b/src/main/java/com/ssu/ongi/domain/device/service/DeviceQueryService.java
@@ -8,6 +8,7 @@ import com.ssu.ongi.domain.device.repository.DeviceRepository;
 import com.ssu.ongi.domain.elder.entity.Elder;
 import com.ssu.ongi.domain.elder.service.ElderQueryService;
 import com.ssu.ongi.domain.member.enums.LoginMode;
+import com.ssu.ongi.domain.member.service.LoginModeValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ public class DeviceQueryService {
 
     private final DeviceRepository deviceRepository;
     private final ElderQueryService elderQueryService;
+    private final LoginModeValidator loginModeValidator;
 
     /**
      * deviceToken으로 디바이스를 조회합니다. (ESP32 인증 시 사용)
@@ -40,7 +42,7 @@ public class DeviceQueryService {
      * 보호자의 어르신에게 등록된 디바이스 상태를 조회합니다.
      */
     public DeviceStatusResponse getDeviceStatus(Long memberId, LoginMode loginMode) {
-        loginMode.validateGuardianOnly();
+        loginModeValidator.validateGuardianOnly(loginMode);
         Elder elder = elderQueryService.getElderByMemberId(memberId);
         Device device = getDeviceByElderId(elder.getId());
         return DeviceStatusResponse.from(device);

--- a/src/main/java/com/ssu/ongi/domain/device/service/DeviceQueryService.java
+++ b/src/main/java/com/ssu/ongi/domain/device/service/DeviceQueryService.java
@@ -2,8 +2,12 @@ package com.ssu.ongi.domain.device.service;
 
 import com.ssu.ongi.common.exception.GeneralException;
 import com.ssu.ongi.common.status.ErrorStatus;
+import com.ssu.ongi.domain.device.dto.response.DeviceStatusResponse;
 import com.ssu.ongi.domain.device.entity.Device;
 import com.ssu.ongi.domain.device.repository.DeviceRepository;
+import com.ssu.ongi.domain.elder.entity.Elder;
+import com.ssu.ongi.domain.elder.service.ElderQueryService;
+import com.ssu.ongi.domain.member.enums.LoginMode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeviceQueryService {
 
     private final DeviceRepository deviceRepository;
+    private final ElderQueryService elderQueryService;
 
     /**
      * deviceToken으로 디바이스를 조회합니다. (ESP32 인증 시 사용)
@@ -29,5 +34,24 @@ public class DeviceQueryService {
     public Device getDeviceByElderId(Long elderId) {
         return deviceRepository.findByElderId(elderId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.DEVICE_NOT_FOUND));
+    }
+
+    /**
+     * 보호자의 어르신에게 등록된 디바이스 상태를 조회합니다.
+     */
+    public DeviceStatusResponse getDeviceStatus(Long memberId, LoginMode loginMode) {
+        validateGuardianOnly(loginMode);
+        Elder elder = elderQueryService.getElderByMemberId(memberId);
+        Device device = getDeviceByElderId(elder.getId());
+        return DeviceStatusResponse.from(device);
+    }
+
+    /**
+     * 어르신 모드인 경우 접근을 차단합니다.
+     */
+    private void validateGuardianOnly(LoginMode loginMode) {
+        if (loginMode == LoginMode.ELDER) {
+            throw new GeneralException(ErrorStatus.ELDER_CANNOT_ACCESS);
+        }
     }
 }

--- a/src/main/java/com/ssu/ongi/domain/device/service/DeviceQueryService.java
+++ b/src/main/java/com/ssu/ongi/domain/device/service/DeviceQueryService.java
@@ -40,18 +40,9 @@ public class DeviceQueryService {
      * 보호자의 어르신에게 등록된 디바이스 상태를 조회합니다.
      */
     public DeviceStatusResponse getDeviceStatus(Long memberId, LoginMode loginMode) {
-        validateGuardianOnly(loginMode);
+        loginMode.validateGuardianOnly();
         Elder elder = elderQueryService.getElderByMemberId(memberId);
         Device device = getDeviceByElderId(elder.getId());
         return DeviceStatusResponse.from(device);
-    }
-
-    /**
-     * 어르신 모드인 경우 접근을 차단합니다.
-     */
-    private void validateGuardianOnly(LoginMode loginMode) {
-        if (loginMode == LoginMode.ELDER) {
-            throw new GeneralException(ErrorStatus.ELDER_CANNOT_ACCESS);
-        }
     }
 }

--- a/src/main/java/com/ssu/ongi/domain/member/enums/LoginMode.java
+++ b/src/main/java/com/ssu/ongi/domain/member/enums/LoginMode.java
@@ -1,6 +1,18 @@
 package com.ssu.ongi.domain.member.enums;
 
+import com.ssu.ongi.common.exception.GeneralException;
+import com.ssu.ongi.common.status.ErrorStatus;
+
 public enum LoginMode {
     GUARDIAN,
-    ELDER
+    ELDER;
+
+    /**
+     * 보호자 전용 기능에서 어르신 모드 접근을 차단합니다.
+     */
+    public void validateGuardianOnly() {
+        if (this == ELDER) {
+            throw new GeneralException(ErrorStatus.ELDER_CANNOT_ACCESS);
+        }
+    }
 }

--- a/src/main/java/com/ssu/ongi/domain/member/enums/LoginMode.java
+++ b/src/main/java/com/ssu/ongi/domain/member/enums/LoginMode.java
@@ -1,18 +1,6 @@
 package com.ssu.ongi.domain.member.enums;
 
-import com.ssu.ongi.common.exception.GeneralException;
-import com.ssu.ongi.common.status.ErrorStatus;
-
 public enum LoginMode {
     GUARDIAN,
-    ELDER;
-
-    /**
-     * 보호자 전용 기능에서 어르신 모드 접근을 차단합니다.
-     */
-    public void validateGuardianOnly() {
-        if (this == ELDER) {
-            throw new GeneralException(ErrorStatus.ELDER_CANNOT_ACCESS);
-        }
-    }
+    ELDER
 }

--- a/src/main/java/com/ssu/ongi/domain/member/service/LoginModeValidator.java
+++ b/src/main/java/com/ssu/ongi/domain/member/service/LoginModeValidator.java
@@ -1,0 +1,19 @@
+package com.ssu.ongi.domain.member.service;
+
+import com.ssu.ongi.common.exception.GeneralException;
+import com.ssu.ongi.common.status.ErrorStatus;
+import com.ssu.ongi.domain.member.enums.LoginMode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LoginModeValidator {
+
+    /**
+     * 보호자 전용 기능에서 어르신 모드 접근을 차단합니다.
+     */
+    public void validateGuardianOnly(LoginMode loginMode) {
+        if (loginMode == LoginMode.ELDER) {
+            throw new GeneralException(ErrorStatus.ELDER_CANNOT_ACCESS);
+        }
+    }
+}

--- a/src/test/java/com/ssu/ongi/domain/device/service/DeviceCommandServiceTest.java
+++ b/src/test/java/com/ssu/ongi/domain/device/service/DeviceCommandServiceTest.java
@@ -11,6 +11,7 @@ import com.ssu.ongi.domain.elder.entity.Elder;
 import com.ssu.ongi.domain.elder.service.ElderQueryService;
 import com.ssu.ongi.domain.medicine.service.MedicationRecordCommandService;
 import com.ssu.ongi.domain.member.enums.LoginMode;
+import com.ssu.ongi.domain.member.service.LoginModeValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
@@ -41,7 +42,8 @@ class DeviceCommandServiceTest {
                 mock(MqttPublisher.class),
                 mock(DeviceSlotCommandService.class),
                 mock(MedicationRecordCommandService.class),
-                mock(ApplicationEventPublisher.class)
+                mock(ApplicationEventPublisher.class),
+                new LoginModeValidator()
         );
     }
 

--- a/src/test/java/com/ssu/ongi/domain/device/service/DeviceQueryServiceTest.java
+++ b/src/test/java/com/ssu/ongi/domain/device/service/DeviceQueryServiceTest.java
@@ -57,6 +57,28 @@ class DeviceQueryServiceTest {
     }
 
     /**
+     * 최초 heartbeat 전 디바이스는 연결 상태 필드가 null로 조회되는지 검증합니다.
+     */
+    @Test
+    void 한번도_연결되지_않은_디바이스는_null_필드로_응답한다() {
+        Elder elder = createElder(1L);
+        Device device = Device.create(elder, "ONGI-001");
+        ReflectionTestUtils.setField(device, "id", 10L);
+
+        when(elderQueryService.getElderByMemberId(1L)).thenReturn(elder);
+        when(deviceRepository.findByElderId(1L)).thenReturn(Optional.of(device));
+
+        DeviceStatusResponse response = deviceQueryService.getDeviceStatus(1L, LoginMode.GUARDIAN);
+
+        assertThat(response.deviceId()).isEqualTo(10L);
+        assertThat(response.serialNumber()).isEqualTo("ONGI-001");
+        assertThat(response.status()).isNull();
+        assertThat(response.lastSeenAt()).isNull();
+        assertThat(response.rssi()).isNull();
+        assertThat(response.uptimeSec()).isNull();
+    }
+
+    /**
      * 등록된 디바이스가 없으면 404 예외가 발생하는지 검증합니다.
      */
     @Test

--- a/src/test/java/com/ssu/ongi/domain/device/service/DeviceQueryServiceTest.java
+++ b/src/test/java/com/ssu/ongi/domain/device/service/DeviceQueryServiceTest.java
@@ -9,6 +9,7 @@ import com.ssu.ongi.domain.device.repository.DeviceRepository;
 import com.ssu.ongi.domain.elder.entity.Elder;
 import com.ssu.ongi.domain.elder.service.ElderQueryService;
 import com.ssu.ongi.domain.member.enums.LoginMode;
+import com.ssu.ongi.domain.member.service.LoginModeValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -32,7 +33,7 @@ class DeviceQueryServiceTest {
     void setUp() {
         deviceRepository = mock(DeviceRepository.class);
         elderQueryService = mock(ElderQueryService.class);
-        deviceQueryService = new DeviceQueryService(deviceRepository, elderQueryService);
+        deviceQueryService = new DeviceQueryService(deviceRepository, elderQueryService, new LoginModeValidator());
     }
 
     /**

--- a/src/test/java/com/ssu/ongi/domain/device/service/DeviceQueryServiceTest.java
+++ b/src/test/java/com/ssu/ongi/domain/device/service/DeviceQueryServiceTest.java
@@ -1,0 +1,111 @@
+package com.ssu.ongi.domain.device.service;
+
+import com.ssu.ongi.common.exception.GeneralException;
+import com.ssu.ongi.common.status.ErrorStatus;
+import com.ssu.ongi.domain.device.dto.response.DeviceStatusResponse;
+import com.ssu.ongi.domain.device.entity.Device;
+import com.ssu.ongi.domain.device.enums.DeviceStatus;
+import com.ssu.ongi.domain.device.repository.DeviceRepository;
+import com.ssu.ongi.domain.elder.entity.Elder;
+import com.ssu.ongi.domain.elder.service.ElderQueryService;
+import com.ssu.ongi.domain.member.enums.LoginMode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class DeviceQueryServiceTest {
+
+    private DeviceRepository deviceRepository;
+    private ElderQueryService elderQueryService;
+    private DeviceQueryService deviceQueryService;
+
+    @BeforeEach
+    void setUp() {
+        deviceRepository = mock(DeviceRepository.class);
+        elderQueryService = mock(ElderQueryService.class);
+        deviceQueryService = new DeviceQueryService(deviceRepository, elderQueryService);
+    }
+
+    /**
+     * 보호자 모드에서 등록된 디바이스 상태를 정상 조회하는지 검증합니다.
+     */
+    @Test
+    void 디바이스_상태를_조회한다() {
+        Elder elder = createElder(1L);
+        Device device = createDevice(10L, elder, "ONGI-001", DeviceStatus.ONLINE, -60, 3600L);
+
+        when(elderQueryService.getElderByMemberId(1L)).thenReturn(elder);
+        when(deviceRepository.findByElderId(1L)).thenReturn(Optional.of(device));
+
+        DeviceStatusResponse response = deviceQueryService.getDeviceStatus(1L, LoginMode.GUARDIAN);
+
+        assertThat(response.deviceId()).isEqualTo(10L);
+        assertThat(response.serialNumber()).isEqualTo("ONGI-001");
+        assertThat(response.status()).isEqualTo(DeviceStatus.ONLINE);
+        assertThat(response.rssi()).isEqualTo(-60);
+        assertThat(response.uptimeSec()).isEqualTo(3600L);
+        assertThat(response.lastSeenAt()).isNotNull();
+    }
+
+    /**
+     * 등록된 디바이스가 없으면 404 예외가 발생하는지 검증합니다.
+     */
+    @Test
+    void 등록된_디바이스가_없으면_상태_조회에_실패한다() {
+        Elder elder = createElder(1L);
+
+        when(elderQueryService.getElderByMemberId(1L)).thenReturn(elder);
+        when(deviceRepository.findByElderId(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> deviceQueryService.getDeviceStatus(1L, LoginMode.GUARDIAN))
+                .isInstanceOf(GeneralException.class)
+                .extracting("errorStatus")
+                .isEqualTo(ErrorStatus.DEVICE_NOT_FOUND);
+    }
+
+    /**
+     * 어르신 모드에서는 디바이스 상태 조회가 차단되는지 검증합니다.
+     */
+    @Test
+    void 어르신_모드이면_상태_조회에_실패한다() {
+        assertThatThrownBy(() -> deviceQueryService.getDeviceStatus(1L, LoginMode.ELDER))
+                .isInstanceOf(GeneralException.class)
+                .extracting("errorStatus")
+                .isEqualTo(ErrorStatus.ELDER_CANNOT_ACCESS);
+
+        verifyNoInteractions(elderQueryService);
+        verifyNoInteractions(deviceRepository);
+    }
+
+    /**
+     * 테스트용 어르신 엔티티에 식별자를 설정합니다.
+     */
+    private Elder createElder(Long id) {
+        Elder elder = Elder.create("홍길동", 80, "부");
+        ReflectionTestUtils.setField(elder, "id", id);
+        return elder;
+    }
+
+    /**
+     * 테스트용 디바이스 엔티티에 상태 조회 필드를 설정합니다.
+     */
+    private Device createDevice(Long id, Elder elder, String serialNumber,
+                                DeviceStatus status, Integer rssi, Long uptimeSec) {
+        Device device = Device.create(elder, serialNumber);
+        ReflectionTestUtils.setField(device, "id", id);
+        ReflectionTestUtils.setField(device, "status", status);
+        ReflectionTestUtils.setField(device, "rssi", rssi);
+        ReflectionTestUtils.setField(device, "uptimeSec", uptimeSec);
+        ReflectionTestUtils.setField(device, "lastSeenAt", LocalDateTime.now());
+        return device;
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

  closed #35

  앱에서 보호자가 현재 디바이스 상태를 확인할 수 있도록 디바이스 상태 조회 API를 추가

  ## PR 유형

  어떤 변경 사항이 있나요?

  - [x] 새로운 기능 추가
  - [ ] 버그 수정
  - [x] 코드 리팩토링
  - [ ] 주석 추가 및 수정
  - [x] 문서 수정
  - [x] 테스트 추가, 테스트 리팩토링
  - [ ] 빌드 부분 혹은 패키지 매니저 수정
  - [ ] 파일 혹은 폴더명 수정
  - [ ] 파일 혹은 폴더 삭제

  ## PR Checklist

  PR이 다음 요구 사항을 충족하는지 확인하세요.

  - [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  - [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

  ## 🧩 작업 내용
  - GET /api/device/status API를 추가
  - 응답 DTO에 아래 필드를 포함
      - deviceId
      - serialNumber
      - status
      - lastSeenAt
      - rssi
      - uptimeSec
  - 등록된 디바이스가 없으면 DEVICE_NOT_FOUND로 404 응답을 반환
  - 어르신 모드 접근 시 ELDER_CANNOT_ACCESS로 403 응답을 반환
  - Swagger 문서에 디바이스 상태 조회 API를 추가
  - 보호자 전용 기능 검증 로직을 LoginModeValidator로 분리
  - 디바이스 상태 조회 단위 테스트를 추가

  검증:
  ./gradlew compileJava
  ./gradlew test --tests com.ssu.ongi.domain.device.service.DeviceQueryServiceTest
  ./gradlew test --tests com.ssu.ongi.domain.device.service.DeviceQueryServiceTest --tests
  com.ssu.ongi.domain.device.service.DeviceCommandServiceTest

  ## 📸 스크린샷(선택)


  📣 To Reviewers
