### PR TITLE
Feat/#38

### DIFF
--- a/src/main/java/com/ssu/ongi/domain/elder/repository/ElderRepository.java
+++ b/src/main/java/com/ssu/ongi/domain/elder/repository/ElderRepository.java
@@ -12,4 +12,7 @@ public interface ElderRepository extends JpaRepository<Elder, Long> {
     Optional<Elder> findByIdAndMemberId(Long elderId, Long memberId);
 
     Optional<Elder> findFirstByMemberId(Long memberId);
+
+    /** FCM 토큰으로 어르신을 조회합니다. 토큰 무효화 시 사용합니다. */
+    Optional<Elder> findByFcmToken(String fcmToken);
 }

--- a/src/main/java/com/ssu/ongi/domain/notification/service/FcmTokenCleanupService.java
+++ b/src/main/java/com/ssu/ongi/domain/notification/service/FcmTokenCleanupService.java
@@ -21,9 +21,10 @@ public class FcmTokenCleanupService {
      * UNREGISTERED/INVALID_ARGUMENT 에러 수신 시 호출됩니다.
      */
     public void deleteByToken(String token) {
-        boolean deleted = deleteMemberToken(token) || deleteElderToken(token);
+        boolean memberDeleted = deleteMemberToken(token);
+        boolean elderDeleted = deleteElderToken(token);
 
-        if (!deleted) {
+        if (!memberDeleted && !elderDeleted) {
             log.warn("[FCM] 무효 토큰 정리 대상 없음 - token={}", token);
         }
     }

--- a/src/main/java/com/ssu/ongi/domain/notification/service/FcmTokenCleanupService.java
+++ b/src/main/java/com/ssu/ongi/domain/notification/service/FcmTokenCleanupService.java
@@ -1,0 +1,52 @@
+package com.ssu.ongi.domain.notification.service;
+
+import com.ssu.ongi.domain.elder.repository.ElderRepository;
+import com.ssu.ongi.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FcmTokenCleanupService {
+
+    private final MemberRepository memberRepository;
+    private final ElderRepository elderRepository;
+
+    /**
+     * 무효 FCM 토큰을 보호자 또는 어르신 테이블에서 삭제합니다.
+     * UNREGISTERED/INVALID_ARGUMENT 에러 수신 시 호출됩니다.
+     */
+    public void deleteByToken(String token) {
+        boolean deleted = deleteMemberToken(token) || deleteElderToken(token);
+
+        if (!deleted) {
+            log.warn("[FCM] 무효 토큰 정리 대상 없음 - token={}", token);
+        }
+    }
+
+    /** 보호자 테이블에서 FCM 토큰을 삭제합니다. 삭제 성공 시 true를 반환합니다. */
+    private boolean deleteMemberToken(String token) {
+        return memberRepository.findByFcmToken(token)
+                .map(member -> {
+                    member.deleteFcmToken();
+                    log.info("[FCM] 보호자 무효 토큰 삭제 - memberId={}", member.getId());
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    /** 어르신 테이블에서 FCM 토큰을 삭제합니다. 삭제 성공 시 true를 반환합니다. */
+    private boolean deleteElderToken(String token) {
+        return elderRepository.findByFcmToken(token)
+                .map(elder -> {
+                    elder.deleteFcmToken();
+                    log.info("[FCM] 어르신 무효 토큰 삭제 - elderId={}", elder.getId());
+                    return true;
+                })
+                .orElse(false);
+    }
+}

--- a/src/main/java/com/ssu/ongi/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/ssu/ongi/domain/notification/service/NotificationCommandService.java
@@ -80,14 +80,15 @@ public class NotificationCommandService {
     }
 
     /**
-     * FCM 메시지를 전송합니다. 일시적 오류 발생 시 1회 재시도하고,
-     * 무효 토큰 오류(UNREGISTERED/INVALID_ARGUMENT)이면 재시도 없이 DB에서 토큰을 삭제합니다.
+     * FCM 메시지를 전송합니다.
+     * - 무효 토큰 오류(UNREGISTERED/INVALID_ARGUMENT): 재시도 없이 DB에서 토큰 삭제
+     * - 일시적 FCM 오류(FirebaseMessagingException): 1회 재시도
+     * - 그 외 예외(프로그래밍 오류 등): 재시도 없이 에러 로그만 기록
      */
     private void sendFcmWithRetry(FcmMessage message, String logContext) {
         try {
             String messageId = fcmService.send(message);
             log.info("[FCM] 전송 성공 - {} messageId={}", logContext, messageId);
-            return;
         } catch (FirebaseMessagingException e) {
             if (isInvalidToken(e)) {
                 log.warn("[FCM] 무효 토큰 감지, 토큰 삭제 - {}", logContext);
@@ -95,11 +96,15 @@ public class NotificationCommandService {
                 return;
             }
             log.warn("[FCM] 1차 전송 실패, 재시도 - {} errorCode={}", logContext, e.getMessagingErrorCode());
+            retrySend(message, logContext);
         } catch (Exception e) {
-            log.warn("[FCM] 1차 전송 중 예외 발생, 재시도 - {} message={}", logContext, e.getMessage());
+            // NPE, IllegalArgumentException 등 프로그래밍 오류는 재시도해도 동일하게 실패하므로 재시도하지 않음
+            log.error("[FCM] 전송 중 예외 발생 (재시도 안 함) - {} message={}", logContext, e.getMessage());
         }
+    }
 
-        // 1회 재시도 (일시적 오류인 경우)
+    /** 1차 전송 실패(일시적 FCM 오류) 후 재시도합니다. */
+    private void retrySend(FcmMessage message, String logContext) {
         try {
             String messageId = fcmService.send(message);
             log.info("[FCM] 재시도 전송 성공 - {} messageId={}", logContext, messageId);

--- a/src/main/java/com/ssu/ongi/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/ssu/ongi/domain/notification/service/NotificationCommandService.java
@@ -1,6 +1,7 @@
 package com.ssu.ongi.domain.notification.service;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
 import com.ssu.ongi.common.fcm.FcmMessage;
 import com.ssu.ongi.common.fcm.FcmService;
 import com.ssu.ongi.domain.device.enums.DeviceStatus;
@@ -21,6 +22,7 @@ import java.util.Map;
 public class NotificationCommandService {
 
     private final FcmService fcmService;
+    private final FcmTokenCleanupService fcmTokenCleanupService;
 
     /**
      * 복약 완료/미복용 이벤트를 보호자에게 FCM으로 전송합니다.
@@ -32,29 +34,95 @@ public class NotificationCommandService {
             return;
         }
 
-        try {
-            FcmMessage message = new FcmMessage(
-                    event.fcmToken(),
-                    getMedicationTitle(event.result()),
-                    getMedicationBody(event.medicineName(), event.result()),
-                    Map.of(
-                            "type", getMedicationType(event.result()).name(),
-                            "memberId", String.valueOf(event.memberId()),
-                            "elderId", String.valueOf(event.elderId()),
-                            "medicineId", String.valueOf(event.medicineId()),
-                            "recordedAt", event.recordedAt().toString()
-                    )
-            );
-            String messageId = fcmService.send(message);
-            log.info("[FCM] 복약 알림 발송 성공 - memberId={}, medicineId={}, result={}, messageId={}",
-                    event.memberId(), event.medicineId(), event.result(), messageId);
-        } catch (FirebaseMessagingException e) {
-            log.error("[FCM] 복약 알림 발송 실패 - memberId={}, medicineId={}, result={}, errorCode={}, message={}",
-                    event.memberId(), event.medicineId(), event.result(), e.getMessagingErrorCode(), e.getMessage());
-        } catch (Exception e) {
-            log.error("[FCM] 복약 알림 처리 중 오류 - memberId={}, medicineId={}, result={}, message={}",
-                    event.memberId(), event.medicineId(), event.result(), e.getMessage());
+        FcmMessage message = new FcmMessage(
+                event.fcmToken(),
+                getMedicationTitle(event.result()),
+                getMedicationBody(event.medicineName(), event.result()),
+                Map.of(
+                        "type", getMedicationType(event.result()).name(),
+                        "memberId", String.valueOf(event.memberId()),
+                        "elderId", String.valueOf(event.elderId()),
+                        "medicineId", String.valueOf(event.medicineId()),
+                        "recordedAt", event.recordedAt().toString()
+                )
+        );
+
+        sendFcmWithRetry(message,
+                "memberId=" + event.memberId() + " medicineId=" + event.medicineId() + " result=" + event.result());
+    }
+
+    /**
+     * 디바이스 오프라인 상태 변경 이벤트를 보호자에게 FCM으로 전송합니다.
+     */
+    public void sendDeviceOffline(DeviceOfflineEvent event) {
+        if (!StringUtils.hasText(event.fcmToken())) {
+            log.info("[FCM] 디바이스 오프라인 알림 생략 - memberId={}, deviceId={}, reason=no_fcm_token",
+                    event.memberId(), event.deviceId());
+            return;
         }
+
+        FcmMessage message = new FcmMessage(
+                event.fcmToken(),
+                getDeviceOfflineTitle(event.status()),
+                getDeviceOfflineBody(event.status()),
+                Map.of(
+                        "type", getDeviceOfflineType(event.status()).name(),
+                        "memberId", String.valueOf(event.memberId()),
+                        "elderId", String.valueOf(event.elderId()),
+                        "deviceId", String.valueOf(event.deviceId()),
+                        "status", event.status().name(),
+                        "lastSeenAt", event.lastSeenAt().toString()
+                )
+        );
+
+        sendFcmWithRetry(message,
+                "memberId=" + event.memberId() + " deviceId=" + event.deviceId() + " status=" + event.status());
+    }
+
+    /**
+     * FCM 메시지를 전송합니다. 일시적 오류 발생 시 1회 재시도하고,
+     * 무효 토큰 오류(UNREGISTERED/INVALID_ARGUMENT)이면 재시도 없이 DB에서 토큰을 삭제합니다.
+     */
+    private void sendFcmWithRetry(FcmMessage message, String logContext) {
+        try {
+            fcmService.send(message);
+            log.info("[FCM] 전송 성공 - {}", logContext);
+            return;
+        } catch (FirebaseMessagingException e) {
+            if (isInvalidToken(e)) {
+                log.warn("[FCM] 무효 토큰 감지, 토큰 삭제 - {}", logContext);
+                fcmTokenCleanupService.deleteByToken(message.token());
+                return;
+            }
+            log.warn("[FCM] 1차 전송 실패, 재시도 - {} errorCode={}", logContext, e.getMessagingErrorCode());
+        } catch (Exception e) {
+            log.warn("[FCM] 1차 전송 중 예외 발생, 재시도 - {} message={}", logContext, e.getMessage());
+        }
+
+        // 1회 재시도 (일시적 오류인 경우)
+        try {
+            fcmService.send(message);
+            log.info("[FCM] 재시도 전송 성공 - {}", logContext);
+        } catch (FirebaseMessagingException e) {
+            if (isInvalidToken(e)) {
+                log.warn("[FCM] 재시도 중 무효 토큰 감지, 토큰 삭제 - {}", logContext);
+                fcmTokenCleanupService.deleteByToken(message.token());
+            } else {
+                log.error("[FCM] 재시도 후 최종 실패 - {} errorCode={}", logContext, e.getMessagingErrorCode());
+            }
+        } catch (Exception e) {
+            log.error("[FCM] 재시도 후 최종 실패 - {} message={}", logContext, e.getMessage());
+        }
+    }
+
+    /**
+     * FCM 에러가 토큰 무효 오류인지 확인합니다.
+     * UNREGISTERED: 앱 삭제 또는 토큰 만료, INVALID_ARGUMENT: 잘못된 토큰 형식
+     */
+    private boolean isInvalidToken(FirebaseMessagingException e) {
+        MessagingErrorCode code = e.getMessagingErrorCode();
+        return code == MessagingErrorCode.UNREGISTERED
+                || code == MessagingErrorCode.INVALID_ARGUMENT;
     }
 
     /** MedicationResult에 대응하는 알림 타입을 반환합니다. */
@@ -76,61 +144,19 @@ public class NotificationCommandService {
                 : medicineName + " 복용이 확인되지 않았어요.";
     }
 
-    /**
-     * 디바이스 오프라인 상태 변경 이벤트를 보호자에게 FCM으로 전송합니다.
-     */
-    public void sendDeviceOffline(DeviceOfflineEvent event) {
-        if (!StringUtils.hasText(event.fcmToken())) {
-            log.info("[FCM] 디바이스 오프라인 알림 생략 - memberId={}, deviceId={}, reason=no_fcm_token",
-                    event.memberId(), event.deviceId());
-            return;
-        }
-
-        try {
-            FcmMessage message = new FcmMessage(
-                    event.fcmToken(),
-                    getDeviceOfflineTitle(event.status()),
-                    getDeviceOfflineBody(event.status()),
-                    Map.of(
-                            "type", getDeviceOfflineType(event.status()).name(),
-                            "memberId", String.valueOf(event.memberId()),
-                            "elderId", String.valueOf(event.elderId()),
-                            "deviceId", String.valueOf(event.deviceId()),
-                            "status", event.status().name(),
-                            "lastSeenAt", event.lastSeenAt().toString()
-                    )
-            );
-            String messageId = fcmService.send(message);
-            log.info("[FCM] 디바이스 오프라인 알림 발송 성공 - memberId={}, deviceId={}, status={}, messageId={}",
-                    event.memberId(), event.deviceId(), event.status(), messageId);
-        } catch (FirebaseMessagingException e) {
-            log.error("[FCM] 디바이스 오프라인 알림 발송 실패 - memberId={}, deviceId={}, status={}, errorCode={}, message={}",
-                    event.memberId(), event.deviceId(), event.status(), e.getMessagingErrorCode(), e.getMessage());
-        } catch (Exception e) {
-            log.error("[FCM] 디바이스 오프라인 알림 처리 중 오류 - memberId={}, deviceId={}, status={}, message={}",
-                    event.memberId(), event.deviceId(), event.status(), e.getMessage());
-        }
-    }
-
-    /**
-     * 디바이스 상태에 맞는 오프라인 알림 타입을 반환합니다.
-     */
+    /** DeviceStatus에 대응하는 오프라인 알림 타입을 반환합니다. */
     private NotificationType getDeviceOfflineType(DeviceStatus status) {
         return status == DeviceStatus.LONG_OFFLINE
                 ? NotificationType.DEVICE_LONG_OFFLINE
                 : NotificationType.DEVICE_TEMP_OFFLINE;
     }
 
-    /**
-     * 디바이스 상태에 맞는 오프라인 알림 제목을 반환합니다.
-     */
+    /** DeviceStatus에 대응하는 오프라인 알림 제목을 반환합니다. */
     private String getDeviceOfflineTitle(DeviceStatus status) {
         return status == DeviceStatus.LONG_OFFLINE ? "디바이스 장시간 오프라인" : "디바이스 연결 불안정";
     }
 
-    /**
-     * 디바이스 상태에 맞는 오프라인 알림 내용을 반환합니다.
-     */
+    /** DeviceStatus에 대응하는 오프라인 알림 본문을 반환합니다. */
     private String getDeviceOfflineBody(DeviceStatus status) {
         return status == DeviceStatus.LONG_OFFLINE
                 ? "디바이스가 장시간 연결되지 않고 있어요."

--- a/src/main/java/com/ssu/ongi/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/ssu/ongi/domain/notification/service/NotificationCommandService.java
@@ -85,8 +85,8 @@ public class NotificationCommandService {
      */
     private void sendFcmWithRetry(FcmMessage message, String logContext) {
         try {
-            fcmService.send(message);
-            log.info("[FCM] 전송 성공 - {}", logContext);
+            String messageId = fcmService.send(message);
+            log.info("[FCM] 전송 성공 - {} messageId={}", logContext, messageId);
             return;
         } catch (FirebaseMessagingException e) {
             if (isInvalidToken(e)) {
@@ -101,8 +101,8 @@ public class NotificationCommandService {
 
         // 1회 재시도 (일시적 오류인 경우)
         try {
-            fcmService.send(message);
-            log.info("[FCM] 재시도 전송 성공 - {}", logContext);
+            String messageId = fcmService.send(message);
+            log.info("[FCM] 재시도 전송 성공 - {} messageId={}", logContext, messageId);
         } catch (FirebaseMessagingException e) {
             if (isInvalidToken(e)) {
                 log.warn("[FCM] 재시도 중 무효 토큰 감지, 토큰 삭제 - {}", logContext);

--- a/src/test/java/com/ssu/ongi/domain/notification/service/FcmTokenCleanupServiceTest.java
+++ b/src/test/java/com/ssu/ongi/domain/notification/service/FcmTokenCleanupServiceTest.java
@@ -38,8 +38,8 @@ class FcmTokenCleanupServiceTest {
 
         assertThat(member.getFcmToken()).isNull();
         assertThat(member.getOsType()).isNull();
-        // 보호자에서 찾았으므로 어르신 조회는 호출되지 않음
-        verify(elderRepository, never()).findByFcmToken("fcm-member-token");
+        // 동일 토큰이 어르신 테이블에도 있을 수 있으므로 항상 두 테이블 모두 조회
+        verify(elderRepository).findByFcmToken("fcm-member-token");
     }
 
     @Test

--- a/src/test/java/com/ssu/ongi/domain/notification/service/FcmTokenCleanupServiceTest.java
+++ b/src/test/java/com/ssu/ongi/domain/notification/service/FcmTokenCleanupServiceTest.java
@@ -1,0 +1,84 @@
+package com.ssu.ongi.domain.notification.service;
+
+import com.ssu.ongi.domain.elder.entity.Elder;
+import com.ssu.ongi.domain.elder.repository.ElderRepository;
+import com.ssu.ongi.domain.member.entity.Member;
+import com.ssu.ongi.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class FcmTokenCleanupServiceTest {
+
+    private MemberRepository memberRepository;
+    private ElderRepository elderRepository;
+    private FcmTokenCleanupService fcmTokenCleanupService;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = mock(MemberRepository.class);
+        elderRepository = mock(ElderRepository.class);
+        fcmTokenCleanupService = new FcmTokenCleanupService(memberRepository, elderRepository);
+    }
+
+    @Test
+    void 보호자_토큰이_존재하면_토큰을_삭제한다() {
+        Member member = createMember(1L, "fcm-member-token");
+        when(memberRepository.findByFcmToken("fcm-member-token")).thenReturn(Optional.of(member));
+
+        fcmTokenCleanupService.deleteByToken("fcm-member-token");
+
+        assertThat(member.getFcmToken()).isNull();
+        assertThat(member.getOsType()).isNull();
+        // 보호자에서 찾았으므로 어르신 조회는 호출되지 않음
+        verify(elderRepository, never()).findByFcmToken("fcm-member-token");
+    }
+
+    @Test
+    void 어르신_토큰이_존재하면_토큰을_삭제한다() {
+        Elder elder = createElder(10L, "fcm-elder-token");
+        when(memberRepository.findByFcmToken("fcm-elder-token")).thenReturn(Optional.empty());
+        when(elderRepository.findByFcmToken("fcm-elder-token")).thenReturn(Optional.of(elder));
+
+        fcmTokenCleanupService.deleteByToken("fcm-elder-token");
+
+        assertThat(elder.getFcmToken()).isNull();
+        assertThat(elder.getOsType()).isNull();
+    }
+
+    @Test
+    void 보호자와_어르신_모두_토큰이_없으면_삭제하지_않는다() {
+        when(memberRepository.findByFcmToken("unknown-token")).thenReturn(Optional.empty());
+        when(elderRepository.findByFcmToken("unknown-token")).thenReturn(Optional.empty());
+
+        // 예외 없이 정상 종료되어야 함
+        fcmTokenCleanupService.deleteByToken("unknown-token");
+
+        verify(memberRepository).findByFcmToken("unknown-token");
+        verify(elderRepository).findByFcmToken("unknown-token");
+    }
+
+    /** 테스트용 보호자 엔티티에 id와 fcmToken을 설정합니다. */
+    private Member createMember(Long id, String fcmToken) {
+        Member member = Member.create("guardian", "encoded-pw", "보호자", "01000000000");
+        ReflectionTestUtils.setField(member, "id", id);
+        ReflectionTestUtils.setField(member, "fcmToken", fcmToken);
+        return member;
+    }
+
+    /** 테스트용 어르신 엔티티에 id와 fcmToken을 설정합니다. */
+    private Elder createElder(Long id, String fcmToken) {
+        Elder elder = Elder.create("어르신", 80, "부");
+        ReflectionTestUtils.setField(elder, "id", id);
+        ReflectionTestUtils.setField(elder, "fcmToken", fcmToken);
+        return elder;
+    }
+}

--- a/src/test/java/com/ssu/ongi/domain/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/com/ssu/ongi/domain/notification/service/NotificationCommandServiceTest.java
@@ -1,0 +1,153 @@
+package com.ssu.ongi.domain.notification.service;
+
+import com.google.firebase.ErrorCode;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.ssu.ongi.common.fcm.FcmService;
+import com.ssu.ongi.domain.medicine.enums.MedicationResult;
+import com.ssu.ongi.domain.notification.event.MedicationEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NotificationCommandServiceTest {
+
+    private FcmService fcmService;
+    private FcmTokenCleanupService fcmTokenCleanupService;
+    private NotificationCommandService notificationCommandService;
+
+    @BeforeEach
+    void setUp() {
+        fcmService = mock(FcmService.class);
+        fcmTokenCleanupService = mock(FcmTokenCleanupService.class);
+        notificationCommandService = new NotificationCommandService(fcmService, fcmTokenCleanupService);
+    }
+
+    @Test
+    void 전송_성공_시_토큰_정리를_호출하지_않는다() throws Exception {
+        when(fcmService.send(any())).thenReturn("msg-id");
+
+        notificationCommandService.sendMedicationAlert(medicationEvent());
+
+        verify(fcmService, times(1)).send(any());
+        verify(fcmTokenCleanupService, never()).deleteByToken(any());
+    }
+
+    @Test
+    void UNREGISTERED_에러_발생_시_재시도_없이_토큰을_정리한다() throws Exception {
+        when(fcmService.send(any())).thenThrow(messagingException(MessagingErrorCode.UNREGISTERED));
+
+        notificationCommandService.sendMedicationAlert(medicationEvent());
+
+        // 재시도 없이 1회만 호출
+        verify(fcmService, times(1)).send(any());
+        verify(fcmTokenCleanupService).deleteByToken("fcm-token");
+    }
+
+    @Test
+    void INVALID_ARGUMENT_에러_발생_시_재시도_없이_토큰을_정리한다() throws Exception {
+        when(fcmService.send(any())).thenThrow(messagingException(MessagingErrorCode.INVALID_ARGUMENT));
+
+        notificationCommandService.sendMedicationAlert(medicationEvent());
+
+        verify(fcmService, times(1)).send(any());
+        verify(fcmTokenCleanupService).deleteByToken("fcm-token");
+    }
+
+    @Test
+    void 일시_오류_발생_시_재시도_후_성공하면_토큰_정리를_호출하지_않는다() throws Exception {
+        when(fcmService.send(any()))
+                .thenThrow(messagingException(null))  // 1차: 일시 오류 (errorCode=null)
+                .thenReturn("msg-id");                 // 재시도: 성공
+
+        notificationCommandService.sendMedicationAlert(medicationEvent());
+
+        verify(fcmService, times(2)).send(any());
+        verify(fcmTokenCleanupService, never()).deleteByToken(any());
+    }
+
+    @Test
+    void 일시_오류_재시도_후에도_실패하면_토큰_정리를_호출하지_않는다() throws Exception {
+        when(fcmService.send(any()))
+                .thenThrow(messagingException(null))  // 1차: 일시 오류
+                .thenThrow(messagingException(null)); // 재시도: 또 일시 오류
+
+        notificationCommandService.sendMedicationAlert(medicationEvent());
+
+        verify(fcmService, times(2)).send(any());
+        verify(fcmTokenCleanupService, never()).deleteByToken(any());
+    }
+
+    @Test
+    void 재시도_중_무효_토큰_에러_발생_시_토큰을_정리한다() throws Exception {
+        when(fcmService.send(any()))
+                .thenThrow(messagingException(null))                               // 1차: 일시 오류
+                .thenThrow(messagingException(MessagingErrorCode.UNREGISTERED));   // 재시도: 무효 토큰
+
+        notificationCommandService.sendMedicationAlert(medicationEvent());
+
+        verify(fcmService, times(2)).send(any());
+        verify(fcmTokenCleanupService).deleteByToken("fcm-token");
+    }
+
+    @Test
+    void FCM_토큰이_없으면_전송을_시도하지_않는다() throws Exception {
+        notificationCommandService.sendMedicationAlert(medicationEventWithNoToken());
+
+        verify(fcmService, never()).send(any());
+        verify(fcmTokenCleanupService, never()).deleteByToken(any());
+    }
+
+    /** 테스트용 복약 이벤트를 생성합니다. */
+    private MedicationEvent medicationEvent() {
+        return new MedicationEvent(
+                MedicationResult.TAKEN,
+                1L, 10L, 100L,
+                "fcm-token",
+                "혈압약",
+                LocalDateTime.now()
+        );
+    }
+
+    /** FCM 토큰이 없는 복약 이벤트를 생성합니다. */
+    private MedicationEvent medicationEventWithNoToken() {
+        return new MedicationEvent(
+                MedicationResult.TAKEN,
+                1L, 10L, 100L,
+                null,
+                "혈압약",
+                LocalDateTime.now()
+        );
+    }
+
+    /**
+     * FirebaseMessagingException은 final 클래스이므로 reflection으로 생성합니다.
+     * errorCode가 null이면 일시적 오류(INTERNAL 등)를 시뮬레이션합니다.
+     */
+    private static FirebaseMessagingException messagingException(MessagingErrorCode errorCode) {
+        try {
+            Constructor<FirebaseMessagingException> constructor =
+                    FirebaseMessagingException.class.getDeclaredConstructor(ErrorCode.class, String.class);
+            constructor.setAccessible(true);
+            FirebaseMessagingException e = constructor.newInstance(ErrorCode.INTERNAL, "test error");
+
+            Field field = FirebaseMessagingException.class.getDeclaredField("errorCode");
+            field.setAccessible(true);
+            field.set(e, errorCode);
+
+            return e;
+        } catch (Exception ex) {
+            throw new RuntimeException("FirebaseMessagingException 생성 실패", ex);
+        }
+    }
+}

--- a/src/test/java/com/ssu/ongi/domain/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/com/ssu/ongi/domain/notification/service/NotificationCommandServiceTest.java
@@ -65,7 +65,7 @@ class NotificationCommandServiceTest {
     }
 
     @Test
-    void 일시_오류_발생_시_재시도_후_성공하면_토큰_정리를_호출하지_않는다() throws Exception {
+    void FirebaseMessagingException_일시_오류_발생_시_재시도_후_성공하면_토큰_정리를_호출하지_않는다() throws Exception {
         when(fcmService.send(any()))
                 .thenThrow(messagingException(null))  // 1차: 일시 오류 (errorCode=null)
                 .thenReturn("msg-id");                 // 재시도: 성공
@@ -77,7 +77,7 @@ class NotificationCommandServiceTest {
     }
 
     @Test
-    void 일시_오류_재시도_후에도_실패하면_토큰_정리를_호출하지_않는다() throws Exception {
+    void FirebaseMessagingException_재시도_후에도_실패하면_토큰_정리를_호출하지_않는다() throws Exception {
         when(fcmService.send(any()))
                 .thenThrow(messagingException(null))  // 1차: 일시 오류
                 .thenThrow(messagingException(null)); // 재시도: 또 일시 오류
@@ -85,6 +85,17 @@ class NotificationCommandServiceTest {
         notificationCommandService.sendMedicationAlert(medicationEvent());
 
         verify(fcmService, times(2)).send(any());
+        verify(fcmTokenCleanupService, never()).deleteByToken(any());
+    }
+
+    @Test
+    void 일반_Exception_발생_시_재시도_없이_종료한다() throws Exception {
+        when(fcmService.send(any())).thenThrow(new RuntimeException("네트워크 오류"));
+
+        notificationCommandService.sendMedicationAlert(medicationEvent());
+
+        // RuntimeException은 재시도하지 않으므로 1회만 호출
+        verify(fcmService, times(1)).send(any());
         verify(fcmTokenCleanupService, never()).deleteByToken(any());
     }
 


### PR DESCRIPTION
#️⃣ 관련 이슈

  closed #38

##  PR 유형

  어떤 변경 사항이 있나요?

  - [x] 새로운 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 주석 추가 및 수정
  - [ ] 문서 수정
  - [x] 테스트 추가, 테스트 리팩토링
  - [ ] 빌드 부분 혹은 패키지 매니저 수정
  - [ ] 파일 혹은 폴더명 수정
  - [ ] 파일 혹은 폴더 삭제

 ## PR Checklist

  PR이 다음 요구 사항을 충족하는지 확인하세요.

  - [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  - [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

##  🧩 작업 내용

  FCM 전송 실패 시 알림이 조용히 유실되는 문제를 개선하기 위해 재시도 로직을 추가하고, 무효 토큰으로 인한 반복 실패를 방지하기 위해 DB에서 토큰을 자동 정리하는 기능 구현

 ## 변경 사항

  - ElderRepository — findByFcmToken() 추가. 무효 토큰이 어르신 테이블에 있는 경우도 조회·삭제할 수 있도록 함
  - FcmTokenCleanupService (신규) — 무효 FCM 토큰을 보호자(Member) → 어르신(Elder) 순서로 조회하여 삭제, 보호자에서 찾으면 어르신 조회를 생략하는 short-circuit 처리 적용
  - NotificationCommandService — sendFcmWithRetry() 공통 메서드 추가. 기존 sendMedicationAlert,  sendDeviceOffline 양쪽에 분산되어 있던 에러 처리를 한 곳으로 통합하고 재시도 + 토큰 정리 로직 적용

  ### 동작 흐름

  FCM 전송 실패
    ├─ UNREGISTERED / INVALID_ARGUMENT (무효 토큰)
    │     → 재시도 없이 FcmTokenCleanupService.deleteByToken() 호출
    │     → Member 또는 Elder에서 토큰 삭제 후 종료
    └─ 그 외 일시적 오류
          → 1회 재시도
               ├─ 성공 → 완료
               └─ 실패 → 무효 토큰이면 토큰 삭제, 아니면 error 로그

 ## 📸 스크린샷(선택)

  

 ## 📣 To Reviewers

