### PR TITLE
[Feat] 복약 시간 알림 스케줄러 추가

### DIFF
--- a/src/main/java/com/ssu/ongi/domain/medicine/repository/MedicationReminderRepository.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/repository/MedicationReminderRepository.java
@@ -20,17 +20,15 @@ public class MedicationReminderRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    /** 오늘 해당 약의 알림이 이미 발송되었는지 확인합니다. */
-    public boolean isAlreadySent(Long medicineId, LocalDate date) {
-        return Boolean.TRUE.equals(
-                redisTemplate.hasKey(buildKey(medicineId, date))
-        );
-    }
-
-    /** 오늘 해당 약의 알림 발송 이력을 기록합니다. */
-    public void markAsSent(Long medicineId, LocalDate date) {
-        redisTemplate.opsForValue()
-                .set(buildKey(medicineId, date), "sent", TTL_HOURS, TimeUnit.HOURS);
+    /**
+     * 발송 이력이 없을 때만 원자적으로 기록하고 true를 반환합니다.
+     * SET NX를 사용해 분산 환경에서의 중복 발송 race condition을 방지합니다.
+     * 이미 발송된 경우 false를 반환합니다.
+     */
+    public boolean markAsSentIfAbsent(Long medicineId, LocalDate date) {
+        Boolean success = redisTemplate.opsForValue()
+                .setIfAbsent(buildKey(medicineId, date), "sent", TTL_HOURS, TimeUnit.HOURS);
+        return Boolean.TRUE.equals(success);
     }
 
     private String buildKey(Long medicineId, LocalDate date) {

--- a/src/main/java/com/ssu/ongi/domain/medicine/repository/MedicationReminderRepository.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/repository/MedicationReminderRepository.java
@@ -1,0 +1,39 @@
+package com.ssu.ongi.domain.medicine.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 복약 시간 알림 중복 발송 방지를 위한 Redis 저장소입니다.
+ * 약(medicineId)과 날짜(date) 조합으로 당일 알림 발송 여부를 관리합니다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class MedicationReminderRepository {
+
+    private static final String REMINDER_PREFIX = "fcm:reminder:";
+    private static final long TTL_HOURS = 25L;  // 하루 지나면 자동 만료 (여유 1시간)
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /** 오늘 해당 약의 알림이 이미 발송되었는지 확인합니다. */
+    public boolean isAlreadySent(Long medicineId, LocalDate date) {
+        return Boolean.TRUE.equals(
+                redisTemplate.hasKey(buildKey(medicineId, date))
+        );
+    }
+
+    /** 오늘 해당 약의 알림 발송 이력을 기록합니다. */
+    public void markAsSent(Long medicineId, LocalDate date) {
+        redisTemplate.opsForValue()
+                .set(buildKey(medicineId, date), "sent", TTL_HOURS, TimeUnit.HOURS);
+    }
+
+    private String buildKey(Long medicineId, LocalDate date) {
+        return REMINDER_PREFIX + medicineId + ":" + date;
+    }
+}

--- a/src/main/java/com/ssu/ongi/domain/medicine/repository/MedicineRepository.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/repository/MedicineRepository.java
@@ -20,4 +20,19 @@ public interface MedicineRepository extends JpaRepository<Medicine, Long> {
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Medicine m WHERE m.elder.id = :elderId")
     void deleteAllByElderId(@Param("elderId") Long elderId);
+
+    /**
+     * 복약 시간의 시·분이 일치하는 약을 어르신·보호자 정보와 함께 조회합니다.
+     * 매분 실행되는 복약 알림 스케줄러에서 사용합니다.
+     */
+    @Query("""
+            SELECT m FROM Medicine m
+            JOIN FETCH m.elder e
+            JOIN FETCH e.member
+            WHERE HOUR(m.scheduledTime) = :hour
+            AND MINUTE(m.scheduledTime) = :minute
+            """)
+    List<Medicine> findAllByScheduledHourAndMinuteWithElder(
+            @Param("hour") int hour,
+            @Param("minute") int minute);
 }

--- a/src/main/java/com/ssu/ongi/domain/medicine/repository/MedicineRepository.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/repository/MedicineRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,17 +23,16 @@ public interface MedicineRepository extends JpaRepository<Medicine, Long> {
     void deleteAllByElderId(@Param("elderId") Long elderId);
 
     /**
-     * 복약 시간의 시·분이 일치하는 약을 어르신·보호자 정보와 함께 조회합니다.
+     * 복약 예정 시각이 일치하는 약을 어르신·보호자 정보와 함께 조회합니다.
      * 매분 실행되는 복약 알림 스케줄러에서 사용합니다.
+     * LocalTime 직접 비교로 인덱스를 활용할 수 있습니다.
      */
     @Query("""
             SELECT m FROM Medicine m
             JOIN FETCH m.elder e
             JOIN FETCH e.member
-            WHERE HOUR(m.scheduledTime) = :hour
-            AND MINUTE(m.scheduledTime) = :minute
+            WHERE m.scheduledTime = :scheduledTime
             """)
-    List<Medicine> findAllByScheduledHourAndMinuteWithElder(
-            @Param("hour") int hour,
-            @Param("minute") int minute);
+    List<Medicine> findAllByScheduledTimeWithElder(
+            @Param("scheduledTime") LocalTime scheduledTime);
 }

--- a/src/main/java/com/ssu/ongi/domain/medicine/service/MedicationReminderScheduler.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/service/MedicationReminderScheduler.java
@@ -27,10 +27,11 @@ public class MedicationReminderScheduler {
 
     /**
      * 매분 정각에 현재 시각과 일치하는 복약 스케줄을 확인하여 알림을 발행합니다.
-     * Redis로 당일 중복 발송을 방지합니다.
+     * Redis SET NX로 당일 중복 발송을 방지합니다.
+     * @Transactional은 @TransactionalEventListener(AFTER_COMMIT) 바인딩에 필요합니다.
      */
     @Scheduled(cron = "0 * * * * *")
-    @Transactional(readOnly = true)
+    @Transactional
     public void sendMedicationReminders() {
         LocalTime now = LocalTime.now(clock).withSecond(0).withNano(0);
         LocalDate today = LocalDate.now(clock);
@@ -41,15 +42,13 @@ public class MedicationReminderScheduler {
     }
 
     /**
-     * 당일 미발송 약에 한해 Redis에 발송 이력을 기록하고 알림 이벤트를 발행합니다.
+     * SET NX로 원자적으로 중복 체크 후 미발송 약에 한해 알림 이벤트를 발행합니다.
      */
     private void publishIfNotSent(Medicine medicine, LocalDate today) {
-        if (reminderRepository.isAlreadySent(medicine.getId(), today)) {
+        if (!reminderRepository.markAsSentIfAbsent(medicine.getId(), today)) {
             log.debug("[복약 알림] 오늘 이미 발송 완료 - medicineId={}", medicine.getId());
             return;
         }
-
-        reminderRepository.markAsSent(medicine.getId(), today);
 
         eventPublisher.publishEvent(new MedicationReminderEvent(
                 medicine.getElder().getMember().getId(),

--- a/src/main/java/com/ssu/ongi/domain/medicine/service/MedicationReminderScheduler.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/service/MedicationReminderScheduler.java
@@ -1,0 +1,66 @@
+package com.ssu.ongi.domain.medicine.service;
+
+import com.ssu.ongi.domain.medicine.entity.Medicine;
+import com.ssu.ongi.domain.medicine.repository.MedicationReminderRepository;
+import com.ssu.ongi.domain.medicine.repository.MedicineRepository;
+import com.ssu.ongi.domain.notification.event.MedicationReminderEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MedicationReminderScheduler {
+
+    private final MedicineRepository medicineRepository;
+    private final MedicationReminderRepository reminderRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final Clock clock;
+
+    /**
+     * 매분 정각에 현재 시각과 일치하는 복약 스케줄을 확인하여 알림을 발행합니다.
+     * Redis로 당일 중복 발송을 방지합니다.
+     */
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional(readOnly = true)
+    public void sendMedicationReminders() {
+        LocalTime now = LocalTime.now(clock).withSecond(0).withNano(0);
+        LocalDate today = LocalDate.now(clock);
+
+        medicineRepository
+                .findAllByScheduledHourAndMinuteWithElder(now.getHour(), now.getMinute())
+                .forEach(medicine -> publishIfNotSent(medicine, today));
+    }
+
+    /**
+     * 당일 미발송 약에 한해 Redis에 발송 이력을 기록하고 알림 이벤트를 발행합니다.
+     */
+    private void publishIfNotSent(Medicine medicine, LocalDate today) {
+        if (reminderRepository.isAlreadySent(medicine.getId(), today)) {
+            log.debug("[복약 알림] 오늘 이미 발송 완료 - medicineId={}", medicine.getId());
+            return;
+        }
+
+        reminderRepository.markAsSent(medicine.getId(), today);
+
+        eventPublisher.publishEvent(new MedicationReminderEvent(
+                medicine.getElder().getMember().getId(),
+                medicine.getElder().getId(),
+                medicine.getId(),
+                medicine.getElder().getMember().getFcmToken(),
+                medicine.getName(),
+                medicine.getScheduledTime()
+        ));
+
+        log.info("[복약 알림] 이벤트 발행 - medicineId={} elderId={} time={}",
+                medicine.getId(), medicine.getElder().getId(), medicine.getScheduledTime());
+    }
+}

--- a/src/main/java/com/ssu/ongi/domain/medicine/service/MedicationReminderScheduler.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/service/MedicationReminderScheduler.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
@@ -28,16 +27,14 @@ public class MedicationReminderScheduler {
     /**
      * 매분 정각에 현재 시각과 일치하는 복약 스케줄을 확인하여 알림을 발행합니다.
      * Redis SET NX로 당일 중복 발송을 방지합니다.
-     * @Transactional은 @TransactionalEventListener(AFTER_COMMIT) 바인딩에 필요합니다.
      */
     @Scheduled(cron = "0 * * * * *")
-    @Transactional
     public void sendMedicationReminders() {
         LocalTime now = LocalTime.now(clock).withSecond(0).withNano(0);
         LocalDate today = LocalDate.now(clock);
 
         medicineRepository
-                .findAllByScheduledHourAndMinuteWithElder(now.getHour(), now.getMinute())
+                .findAllByScheduledTimeWithElder(now)
                 .forEach(medicine -> publishIfNotSent(medicine, today));
     }
 

--- a/src/main/java/com/ssu/ongi/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/ssu/ongi/domain/notification/enums/NotificationType.java
@@ -3,6 +3,7 @@ package com.ssu.ongi.domain.notification.enums;
 public enum NotificationType {
     MEDICATION_TAKEN,
     MEDICATION_MISSED,
+    MEDICATION_REMINDER,
     DEVICE_TEMP_OFFLINE,
     DEVICE_LONG_OFFLINE
 }

--- a/src/main/java/com/ssu/ongi/domain/notification/event/MedicationReminderEvent.java
+++ b/src/main/java/com/ssu/ongi/domain/notification/event/MedicationReminderEvent.java
@@ -1,0 +1,14 @@
+package com.ssu.ongi.domain.notification.event;
+
+import java.time.LocalTime;
+
+/** 복약 시간 도래 시 보호자에게 FCM 알림을 전송하기 위한 이벤트입니다. */
+public record MedicationReminderEvent(
+        Long memberId,
+        Long elderId,
+        Long medicineId,
+        String fcmToken,
+        String medicineName,
+        LocalTime scheduledTime
+) {
+}

--- a/src/main/java/com/ssu/ongi/domain/notification/event/NotificationEventHandler.java
+++ b/src/main/java/com/ssu/ongi/domain/notification/event/NotificationEventHandler.java
@@ -2,6 +2,7 @@ package com.ssu.ongi.domain.notification.event;
 
 import com.ssu.ongi.domain.notification.service.NotificationCommandService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -24,9 +25,10 @@ public class NotificationEventHandler {
 
     /**
      * 복약 시간 알림 이벤트를 수신하여 FCM 알림을 전송합니다.
+     * 스케줄러는 트랜잭션 없이 이벤트를 발행하므로 @EventListener를 사용합니다.
      */
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handleMedicationReminder(MedicationReminderEvent event) {
         notificationCommandService.sendMedicationReminder(event);
     }

--- a/src/main/java/com/ssu/ongi/domain/notification/event/NotificationEventHandler.java
+++ b/src/main/java/com/ssu/ongi/domain/notification/event/NotificationEventHandler.java
@@ -23,6 +23,15 @@ public class NotificationEventHandler {
     }
 
     /**
+     * 복약 시간 알림 이벤트를 수신하여 FCM 알림을 전송합니다.
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMedicationReminder(MedicationReminderEvent event) {
+        notificationCommandService.sendMedicationReminder(event);
+    }
+
+    /**
      * 디바이스 오프라인 이벤트를 수신하여 FCM 알림을 전송합니다.
      */
     @Async

--- a/src/main/java/com/ssu/ongi/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/ssu/ongi/domain/notification/service/NotificationCommandService.java
@@ -9,6 +9,7 @@ import com.ssu.ongi.domain.medicine.enums.MedicationResult;
 import com.ssu.ongi.domain.notification.enums.NotificationType;
 import com.ssu.ongi.domain.notification.event.DeviceOfflineEvent;
 import com.ssu.ongi.domain.notification.event.MedicationEvent;
+import com.ssu.ongi.domain.notification.event.MedicationReminderEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -49,6 +50,33 @@ public class NotificationCommandService {
 
         sendFcmWithRetry(message,
                 "memberId=" + event.memberId() + " medicineId=" + event.medicineId() + " result=" + event.result());
+    }
+
+    /**
+     * 복약 시간 알림 이벤트를 보호자에게 FCM으로 전송합니다.
+     */
+    public void sendMedicationReminder(MedicationReminderEvent event) {
+        if (!StringUtils.hasText(event.fcmToken())) {
+            log.info("[FCM] 복약 시간 알림 생략 - memberId={}, medicineId={}, reason=no_fcm_token",
+                    event.memberId(), event.medicineId());
+            return;
+        }
+
+        FcmMessage message = new FcmMessage(
+                event.fcmToken(),
+                "복약 시간 알림",
+                event.medicineName() + " 복용 시간이에요.",
+                Map.of(
+                        "type", NotificationType.MEDICATION_REMINDER.name(),
+                        "memberId", String.valueOf(event.memberId()),
+                        "elderId", String.valueOf(event.elderId()),
+                        "medicineId", String.valueOf(event.medicineId()),
+                        "scheduledTime", event.scheduledTime().toString()
+                )
+        );
+
+        sendFcmWithRetry(message,
+                "memberId=" + event.memberId() + " medicineId=" + event.medicineId());
     }
 
     /**

--- a/src/test/java/com/ssu/ongi/domain/medicine/service/MedicationReminderSchedulerTest.java
+++ b/src/test/java/com/ssu/ongi/domain/medicine/service/MedicationReminderSchedulerTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -52,7 +51,7 @@ class MedicationReminderSchedulerTest {
     @Test
     void 복약_시간이_일치하면_알림_이벤트를_발행한다() {
         Medicine medicine = createMedicine(1L, "혈압약", LocalTime.of(8, 0), "fcm-token");
-        when(medicineRepository.findAllByScheduledHourAndMinuteWithElder(8, 0))
+        when(medicineRepository.findAllByScheduledTimeWithElder(LocalTime.of(8, 0)))
                 .thenReturn(List.of(medicine));
         when(reminderRepository.markAsSentIfAbsent(1L, TODAY)).thenReturn(true);
 
@@ -71,7 +70,7 @@ class MedicationReminderSchedulerTest {
     @Test
     void 당일_이미_발송된_약은_이벤트를_발행하지_않는다() {
         Medicine medicine = createMedicine(1L, "혈압약", LocalTime.of(8, 0), "fcm-token");
-        when(medicineRepository.findAllByScheduledHourAndMinuteWithElder(8, 0))
+        when(medicineRepository.findAllByScheduledTimeWithElder(LocalTime.of(8, 0)))
                 .thenReturn(List.of(medicine));
         when(reminderRepository.markAsSentIfAbsent(1L, TODAY)).thenReturn(false);
 
@@ -82,7 +81,7 @@ class MedicationReminderSchedulerTest {
 
     @Test
     void 현재_시각에_해당하는_약이_없으면_이벤트를_발행하지_않는다() {
-        when(medicineRepository.findAllByScheduledHourAndMinuteWithElder(anyInt(), anyInt()))
+        when(medicineRepository.findAllByScheduledTimeWithElder(any(LocalTime.class)))
                 .thenReturn(List.of());
 
         scheduler.sendMedicationReminders();
@@ -94,7 +93,7 @@ class MedicationReminderSchedulerTest {
     void 여러_약이_같은_시간에_등록되어_있으면_각각_이벤트를_발행한다() {
         Medicine medicine1 = createMedicine(1L, "혈압약", LocalTime.of(8, 0), "fcm-token-1");
         Medicine medicine2 = createMedicine(2L, "당뇨약", LocalTime.of(8, 0), "fcm-token-2");
-        when(medicineRepository.findAllByScheduledHourAndMinuteWithElder(8, 0))
+        when(medicineRepository.findAllByScheduledTimeWithElder(LocalTime.of(8, 0)))
                 .thenReturn(List.of(medicine1, medicine2));
         when(reminderRepository.markAsSentIfAbsent(1L, TODAY)).thenReturn(true);
         when(reminderRepository.markAsSentIfAbsent(2L, TODAY)).thenReturn(true);

--- a/src/test/java/com/ssu/ongi/domain/medicine/service/MedicationReminderSchedulerTest.java
+++ b/src/test/java/com/ssu/ongi/domain/medicine/service/MedicationReminderSchedulerTest.java
@@ -1,0 +1,126 @@
+package com.ssu.ongi.domain.medicine.service;
+
+import com.ssu.ongi.domain.elder.entity.Elder;
+import com.ssu.ongi.domain.medicine.entity.Medicine;
+import com.ssu.ongi.domain.medicine.repository.MedicationReminderRepository;
+import com.ssu.ongi.domain.medicine.repository.MedicineRepository;
+import com.ssu.ongi.domain.member.entity.Member;
+import com.ssu.ongi.domain.notification.event.MedicationReminderEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MedicationReminderSchedulerTest {
+
+    // 2026-05-29 08:00:00 KST (= 2026-05-28T23:00:00Z)
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.parse("2026-05-28T23:00:00Z"), KST);
+    private static final LocalDate TODAY = LocalDate.of(2026, 5, 29);
+
+    private MedicineRepository medicineRepository;
+    private MedicationReminderRepository reminderRepository;
+    private ApplicationEventPublisher eventPublisher;
+    private MedicationReminderScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        medicineRepository = mock(MedicineRepository.class);
+        reminderRepository = mock(MedicationReminderRepository.class);
+        eventPublisher = mock(ApplicationEventPublisher.class);
+        scheduler = new MedicationReminderScheduler(
+                medicineRepository, reminderRepository, eventPublisher, FIXED_CLOCK);
+    }
+
+    @Test
+    void 복약_시간이_일치하면_알림_이벤트를_발행한다() {
+        Medicine medicine = createMedicine(1L, "혈압약", LocalTime.of(8, 0), "fcm-token");
+        when(medicineRepository.findAllByScheduledHourAndMinuteWithElder(8, 0))
+                .thenReturn(List.of(medicine));
+        when(reminderRepository.isAlreadySent(1L, TODAY)).thenReturn(false);
+
+        scheduler.sendMedicationReminders();
+
+        ArgumentCaptor<MedicationReminderEvent> captor =
+                ArgumentCaptor.forClass(MedicationReminderEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        verify(reminderRepository).markAsSent(1L, TODAY);
+
+        MedicationReminderEvent event = captor.getValue();
+        assertThat(event.medicineName()).isEqualTo("혈압약");
+        assertThat(event.scheduledTime()).isEqualTo(LocalTime.of(8, 0));
+        assertThat(event.fcmToken()).isEqualTo("fcm-token");
+    }
+
+    @Test
+    void 당일_이미_발송된_약은_이벤트를_발행하지_않는다() {
+        Medicine medicine = createMedicine(1L, "혈압약", LocalTime.of(8, 0), "fcm-token");
+        when(medicineRepository.findAllByScheduledHourAndMinuteWithElder(8, 0))
+                .thenReturn(List.of(medicine));
+        when(reminderRepository.isAlreadySent(1L, TODAY)).thenReturn(true);
+
+        scheduler.sendMedicationReminders();
+
+        verify(eventPublisher, never()).publishEvent(any());
+        verify(reminderRepository, never()).markAsSent(any(), any());
+    }
+
+    @Test
+    void 현재_시각에_해당하는_약이_없으면_이벤트를_발행하지_않는다() {
+        when(medicineRepository.findAllByScheduledHourAndMinuteWithElder(anyInt(), anyInt()))
+                .thenReturn(List.of());
+
+        scheduler.sendMedicationReminders();
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void 여러_약이_같은_시간에_등록되어_있으면_각각_이벤트를_발행한다() {
+        Medicine medicine1 = createMedicine(1L, "혈압약", LocalTime.of(8, 0), "fcm-token-1");
+        Medicine medicine2 = createMedicine(2L, "당뇨약", LocalTime.of(8, 0), "fcm-token-2");
+        when(medicineRepository.findAllByScheduledHourAndMinuteWithElder(8, 0))
+                .thenReturn(List.of(medicine1, medicine2));
+        when(reminderRepository.isAlreadySent(1L, TODAY)).thenReturn(false);
+        when(reminderRepository.isAlreadySent(2L, TODAY)).thenReturn(false);
+
+        scheduler.sendMedicationReminders();
+
+        ArgumentCaptor<MedicationReminderEvent> captor =
+                ArgumentCaptor.forClass(MedicationReminderEvent.class);
+        verify(eventPublisher, org.mockito.Mockito.times(2)).publishEvent(captor.capture());
+        assertThat(captor.getAllValues()).hasSize(2);
+    }
+
+    /** 테스트용 Medicine 엔티티를 생성합니다. */
+    private Medicine createMedicine(Long id, String name, LocalTime scheduledTime, String fcmToken) {
+        Member member = Member.create("guardian", "encoded-pw", "보호자", "01000000000");
+        ReflectionTestUtils.setField(member, "id", 10L);
+        ReflectionTestUtils.setField(member, "fcmToken", fcmToken);
+
+        Elder elder = Elder.create("어르신", 80, "부");
+        ReflectionTestUtils.setField(elder, "id", 20L);
+        member.addElder(elder);
+
+        Medicine medicine = Medicine.create(elder, name, scheduledTime);
+        ReflectionTestUtils.setField(medicine, "id", id);
+        return medicine;
+    }
+}

--- a/src/test/java/com/ssu/ongi/domain/medicine/service/MedicationReminderSchedulerTest.java
+++ b/src/test/java/com/ssu/ongi/domain/medicine/service/MedicationReminderSchedulerTest.java
@@ -54,14 +54,13 @@ class MedicationReminderSchedulerTest {
         Medicine medicine = createMedicine(1L, "혈압약", LocalTime.of(8, 0), "fcm-token");
         when(medicineRepository.findAllByScheduledHourAndMinuteWithElder(8, 0))
                 .thenReturn(List.of(medicine));
-        when(reminderRepository.isAlreadySent(1L, TODAY)).thenReturn(false);
+        when(reminderRepository.markAsSentIfAbsent(1L, TODAY)).thenReturn(true);
 
         scheduler.sendMedicationReminders();
 
         ArgumentCaptor<MedicationReminderEvent> captor =
                 ArgumentCaptor.forClass(MedicationReminderEvent.class);
         verify(eventPublisher).publishEvent(captor.capture());
-        verify(reminderRepository).markAsSent(1L, TODAY);
 
         MedicationReminderEvent event = captor.getValue();
         assertThat(event.medicineName()).isEqualTo("혈압약");
@@ -74,12 +73,11 @@ class MedicationReminderSchedulerTest {
         Medicine medicine = createMedicine(1L, "혈압약", LocalTime.of(8, 0), "fcm-token");
         when(medicineRepository.findAllByScheduledHourAndMinuteWithElder(8, 0))
                 .thenReturn(List.of(medicine));
-        when(reminderRepository.isAlreadySent(1L, TODAY)).thenReturn(true);
+        when(reminderRepository.markAsSentIfAbsent(1L, TODAY)).thenReturn(false);
 
         scheduler.sendMedicationReminders();
 
         verify(eventPublisher, never()).publishEvent(any());
-        verify(reminderRepository, never()).markAsSent(any(), any());
     }
 
     @Test
@@ -98,8 +96,8 @@ class MedicationReminderSchedulerTest {
         Medicine medicine2 = createMedicine(2L, "당뇨약", LocalTime.of(8, 0), "fcm-token-2");
         when(medicineRepository.findAllByScheduledHourAndMinuteWithElder(8, 0))
                 .thenReturn(List.of(medicine1, medicine2));
-        when(reminderRepository.isAlreadySent(1L, TODAY)).thenReturn(false);
-        when(reminderRepository.isAlreadySent(2L, TODAY)).thenReturn(false);
+        when(reminderRepository.markAsSentIfAbsent(1L, TODAY)).thenReturn(true);
+        when(reminderRepository.markAsSentIfAbsent(2L, TODAY)).thenReturn(true);
 
         scheduler.sendMedicationReminders();
 


### PR DESCRIPTION
#️⃣ 관련 이슈

  closed #39

##  PR 유형

  어떤 변경 사항이 있나요?

  - [x] 새로운 기능 추가
  - [x] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 주석 추가 및 수정
  - [ ] 문서 수정
  - [x] 테스트 추가, 테스트 리팩토링
  - [ ] 빌드 부분 혹은 패키지 매니저 수정
  - [ ] 파일 혹은 폴더명 수정
  - [ ] 파일 혹은 폴더 삭제

##  PR Checklist

  PR이 다음 요구 사항을 충족하는지 확인하세요.

  - [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  - [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

##   🧩 작업 내용
-   등록된 복약 스케줄의 시간이 되면 보호자에게 자동으로 FCM 알림을 전송하는 스케줄러를 구현 
- 하루에 같은 약에 대해 알림이 중복 발송되지 않도록 Redis SET NX를 통해 분산 환경에서도 안전한 중복 방지 처리

##  변경 사항
  - NotificationType - MEDICATION_REMINDER 알림 타입 추가
  - MedicineRepository - HOUR/MINUTE 기반 복약 시간 조회 쿼리 추가. elder·member를 JOIN FETCH로 함께 로드
  - MedicationReminderRepository (신규) - Redis 기반 중복 발송 방지. markAsSentIfAbsent(SET NX)로
  체크·기록을 원자적으로 처리해 Blue-Green 배포 환경의 race condition 방지
  - MedicationReminderEvent (신규) - 복약 알림 이벤트 레코드
  - MedicationReminderScheduler (신규) - @Scheduled(cron = "0 * * * * *")로 매분 실행. Clock 기반 KST
  시각으로 해당 시간의 약을 조회하고 이벤트 발행
  - NotificationEventHandler — handleMedicationReminder 핸들러 추가
  - NotificationCommandService — sendMedicationReminder 추가. 기존 sendFcmWithRetry 재사용

  동작 흐름
    → Redis SET NX: 오늘 이미 발송 이력 있으면 스킵
    → MedicationReminderEvent 발행
    → 트랜잭션 커밋 후 @Async
    → FCM "복약 시간 알림" 전송 (sendFcmWithRetry 재사용)

  ## 📸 스크린샷(선택)

  

##   📣 To Reviewers
