### PR TITLE
[Feat] 날짜별 복약 상태 통합 조회 API 추가

### DIFF
--- a/src/main/java/com/ssu/ongi/domain/device/repository/DeviceSlotRepository.java
+++ b/src/main/java/com/ssu/ongi/domain/device/repository/DeviceSlotRepository.java
@@ -36,6 +36,9 @@ public interface DeviceSlotRepository extends JpaRepository<DeviceSlot, Long> {
 
     List<DeviceSlot> findAllByElderIdOrderByMedicineScheduledTimeAsc(Long elderId);
 
-    @Query("SELECT ds FROM DeviceSlot ds JOIN FETCH ds.medicine WHERE ds.elder.id = :elderId")
+    @Query("SELECT ds FROM DeviceSlot ds " +
+            "JOIN FETCH ds.medicine " +
+            "JOIN FETCH ds.device " +
+            "WHERE ds.elder.id = :elderId")
     List<DeviceSlot> findAllWithMedicineByElderId(@Param("elderId") Long elderId);
 }

--- a/src/main/java/com/ssu/ongi/domain/medicine/controller/MedicationRecordController.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/controller/MedicationRecordController.java
@@ -1,9 +1,11 @@
 package com.ssu.ongi.domain.medicine.controller;
 
+import com.ssu.ongi.common.jwt.MemberPrincipal;
 import com.ssu.ongi.common.response.ApiResponse;
 import com.ssu.ongi.common.status.SuccessStatus;
 import com.ssu.ongi.domain.medicine.controller.docs.MedicationRecordControllerDocs;
 import com.ssu.ongi.domain.medicine.dto.request.MedicationRecordSyncRequest;
+import com.ssu.ongi.domain.medicine.dto.response.DailyMedicationStatusResponse;
 import com.ssu.ongi.domain.medicine.dto.response.MedicationIntakeResponse;
 import com.ssu.ongi.domain.medicine.service.MedicationRecordCommandService;
 import com.ssu.ongi.domain.medicine.service.MedicationRecordQueryService;
@@ -11,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,6 +49,17 @@ public class MedicationRecordController implements MedicationRecordControllerDoc
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
         List<MedicationIntakeResponse> response = medicationRecordQueryService.getRecordsByDate(elderId, date);
+        return ApiResponse.success(SuccessStatus.GET_MEDICATION_RECORD_SUCCESS, response);
+    }
+
+    @Override
+    @GetMapping("/daily")
+    public ResponseEntity<ApiResponse<List<DailyMedicationStatusResponse>>> getDailyMedicationStatuses(
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        List<DailyMedicationStatusResponse> response =
+                medicationRecordQueryService.getDailyMedicationStatuses(principal.memberId(), date);
         return ApiResponse.success(SuccessStatus.GET_MEDICATION_RECORD_SUCCESS, response);
     }
 

--- a/src/main/java/com/ssu/ongi/domain/medicine/controller/docs/MedicationRecordControllerDocs.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/controller/docs/MedicationRecordControllerDocs.java
@@ -1,7 +1,9 @@
 package com.ssu.ongi.domain.medicine.controller.docs;
 
+import com.ssu.ongi.common.jwt.MemberPrincipal;
 import com.ssu.ongi.common.response.ApiResponse;
 import com.ssu.ongi.domain.medicine.dto.request.MedicationRecordSyncRequest;
+import com.ssu.ongi.domain.medicine.dto.response.DailyMedicationStatusResponse;
 import com.ssu.ongi.domain.medicine.dto.response.MedicationIntakeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -49,6 +52,18 @@ public interface MedicationRecordControllerDocs {
     })
     ResponseEntity<ApiResponse<List<MedicationIntakeResponse>>> getRecordsByDate(
             @Parameter(description = "어르신 ID", required = true) @RequestParam Long elderId,
+            @Parameter(description = "조회 날짜 (yyyy-MM-dd)", required = true) @RequestParam LocalDate date
+    );
+
+    @Operation(summary = "날짜별 복약 상태 조회", description = "로그인한 보호자의 어르신 복약 스케줄과 특정 날짜의 복약 기록을 함께 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공"
+            )
+    })
+    ResponseEntity<ApiResponse<List<DailyMedicationStatusResponse>>> getDailyMedicationStatuses(
+            @AuthenticationPrincipal MemberPrincipal principal,
             @Parameter(description = "조회 날짜 (yyyy-MM-dd)", required = true) @RequestParam LocalDate date
     );
 

--- a/src/main/java/com/ssu/ongi/domain/medicine/dto/response/DailyMedicationStatusResponse.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/dto/response/DailyMedicationStatusResponse.java
@@ -1,0 +1,42 @@
+package com.ssu.ongi.domain.medicine.dto.response;
+
+import com.ssu.ongi.common.exception.GeneralException;
+import com.ssu.ongi.common.status.ErrorStatus;
+import com.ssu.ongi.domain.device.entity.DeviceSlot;
+import com.ssu.ongi.domain.medicine.entity.MedicationRecord;
+import com.ssu.ongi.domain.medicine.entity.Medicine;
+import com.ssu.ongi.domain.medicine.enums.MedicationResult;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record DailyMedicationStatusResponse(
+        Long medicineId,
+        String medicineName,
+        LocalTime scheduledTime,
+        Integer slotNumber,
+        Long deviceId,
+        boolean taken,
+        MedicationResult result,
+        LocalDateTime recordedAt
+) {
+    public static DailyMedicationStatusResponse of(Medicine medicine, DeviceSlot deviceSlot, MedicationRecord record) {
+        if (deviceSlot == null) {
+            throw new GeneralException(ErrorStatus.DEVICE_NOT_FOUND);
+        }
+
+        MedicationResult result = record == null ? null : record.getResult();
+        LocalDateTime recordedAt = record == null ? null : record.getRecordedAt();
+
+        return new DailyMedicationStatusResponse(
+                medicine.getId(),
+                medicine.getName(),
+                medicine.getScheduledTime(),
+                deviceSlot.getSlotNumber(),
+                deviceSlot.getDevice().getId(),
+                result == MedicationResult.TAKEN,
+                result,
+                recordedAt
+        );
+    }
+}

--- a/src/main/java/com/ssu/ongi/domain/medicine/dto/response/DailyMedicationStatusResponse.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/dto/response/DailyMedicationStatusResponse.java
@@ -1,7 +1,5 @@
 package com.ssu.ongi.domain.medicine.dto.response;
 
-import com.ssu.ongi.common.exception.GeneralException;
-import com.ssu.ongi.common.status.ErrorStatus;
 import com.ssu.ongi.domain.device.entity.DeviceSlot;
 import com.ssu.ongi.domain.medicine.entity.MedicationRecord;
 import com.ssu.ongi.domain.medicine.entity.Medicine;
@@ -21,10 +19,6 @@ public record DailyMedicationStatusResponse(
         LocalDateTime recordedAt
 ) {
     public static DailyMedicationStatusResponse of(Medicine medicine, DeviceSlot deviceSlot, MedicationRecord record) {
-        if (deviceSlot == null) {
-            throw new GeneralException(ErrorStatus.DEVICE_NOT_FOUND);
-        }
-
         MedicationResult result = record == null ? null : record.getResult();
         LocalDateTime recordedAt = record == null ? null : record.getRecordedAt();
 

--- a/src/main/java/com/ssu/ongi/domain/medicine/service/MedicationRecordQueryService.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/service/MedicationRecordQueryService.java
@@ -63,7 +63,7 @@ public class MedicationRecordQueryService {
                 .collect(Collectors.toMap(
                         record -> record.getMedicine().getId(),
                         Function.identity(),
-                        (first, second) -> second
+                        (first, second) -> first.getRecordedAt().isAfter(second.getRecordedAt()) ? first : second
                 ));
         Map<Long, DeviceSlot> slotMap = deviceSlotQueryService.getSlotMapByElderId(elderId);
 

--- a/src/main/java/com/ssu/ongi/domain/medicine/service/MedicationRecordQueryService.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/service/MedicationRecordQueryService.java
@@ -8,6 +8,7 @@ import com.ssu.ongi.domain.elder.service.ElderQueryService;
 import com.ssu.ongi.domain.medicine.dto.response.DailyMedicationStatusResponse;
 import com.ssu.ongi.domain.medicine.dto.response.MedicationIntakeResponse;
 import com.ssu.ongi.domain.medicine.entity.MedicationRecord;
+import com.ssu.ongi.domain.medicine.entity.Medicine;
 import com.ssu.ongi.domain.medicine.repository.MedicationRecordRepository;
 import com.ssu.ongi.domain.medicine.repository.MedicineRepository;
 import lombok.RequiredArgsConstructor;
@@ -67,10 +68,19 @@ public class MedicationRecordQueryService {
                 ));
         Map<Long, DeviceSlot> slotMap = deviceSlotQueryService.getSlotMapByElderId(elderId);
 
-        return medicineRepository.findAllByElderIdOrderByScheduledTimeAsc(elderId)
-                .stream()
+        List<Medicine> medicines = medicineRepository.findAllByElderIdOrderByScheduledTimeAsc(elderId);
+
+        medicines.forEach(medicine -> validateDeviceSlotExists(slotMap, medicine.getId()));
+
+        return medicines.stream()
                 .map(medicine -> DailyMedicationStatusResponse.of(
                         medicine, slotMap.get(medicine.getId()), recordMap.get(medicine.getId())))
                 .toList();
+    }
+
+    private void validateDeviceSlotExists(Map<Long, DeviceSlot> slotMap, Long medicineId) {
+        if (!slotMap.containsKey(medicineId)) {
+            throw new GeneralException(ErrorStatus.DEVICE_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/ssu/ongi/domain/medicine/service/MedicationRecordQueryService.java
+++ b/src/main/java/com/ssu/ongi/domain/medicine/service/MedicationRecordQueryService.java
@@ -2,7 +2,12 @@ package com.ssu.ongi.domain.medicine.service;
 
 import com.ssu.ongi.common.exception.GeneralException;
 import com.ssu.ongi.common.status.ErrorStatus;
+import com.ssu.ongi.domain.device.entity.DeviceSlot;
+import com.ssu.ongi.domain.device.service.DeviceSlotQueryService;
+import com.ssu.ongi.domain.elder.service.ElderQueryService;
+import com.ssu.ongi.domain.medicine.dto.response.DailyMedicationStatusResponse;
 import com.ssu.ongi.domain.medicine.dto.response.MedicationIntakeResponse;
+import com.ssu.ongi.domain.medicine.entity.MedicationRecord;
 import com.ssu.ongi.domain.medicine.repository.MedicationRecordRepository;
 import com.ssu.ongi.domain.medicine.repository.MedicineRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +18,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -21,6 +29,8 @@ public class MedicationRecordQueryService {
 
     private final MedicationRecordRepository medicationRecordRepository;
     private final MedicineRepository medicineRepository;
+    private final ElderQueryService elderQueryService;
+    private final DeviceSlotQueryService deviceSlotQueryService;
 
     public List<MedicationIntakeResponse> getRecordsByDate(Long elderId, LocalDate date) {
         LocalDateTime start = date.atStartOfDay();
@@ -39,6 +49,28 @@ public class MedicationRecordQueryService {
         return medicationRecordRepository.findAllByMedicineId(medicineId)
                 .stream()
                 .map(MedicationIntakeResponse::from)
+                .toList();
+    }
+
+    public List<DailyMedicationStatusResponse> getDailyMedicationStatuses(Long memberId, LocalDate date) {
+        Long elderId = elderQueryService.getElderByMemberId(memberId).getId();
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.atTime(LocalTime.MAX);
+
+        Map<Long, MedicationRecord> recordMap = medicationRecordRepository
+                .findAllByElderIdAndRecordedAtBetween(elderId, start, end)
+                .stream()
+                .collect(Collectors.toMap(
+                        record -> record.getMedicine().getId(),
+                        Function.identity(),
+                        (first, second) -> second
+                ));
+        Map<Long, DeviceSlot> slotMap = deviceSlotQueryService.getSlotMapByElderId(elderId);
+
+        return medicineRepository.findAllByElderIdOrderByScheduledTimeAsc(elderId)
+                .stream()
+                .map(medicine -> DailyMedicationStatusResponse.of(
+                        medicine, slotMap.get(medicine.getId()), recordMap.get(medicine.getId())))
                 .toList();
     }
 }

--- a/src/test/java/com/ssu/ongi/domain/medicine/service/MedicationRecordQueryServiceTest.java
+++ b/src/test/java/com/ssu/ongi/domain/medicine/service/MedicationRecordQueryServiceTest.java
@@ -1,5 +1,7 @@
 package com.ssu.ongi.domain.medicine.service;
 
+import com.ssu.ongi.common.exception.GeneralException;
+import com.ssu.ongi.common.status.ErrorStatus;
 import com.ssu.ongi.domain.device.entity.Device;
 import com.ssu.ongi.domain.device.entity.DeviceSlot;
 import com.ssu.ongi.domain.device.service.DeviceSlotQueryService;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -85,6 +88,58 @@ class MedicationRecordQueryServiceTest {
         assertThat(result.get(1).taken()).isFalse();
         assertThat(result.get(1).result()).isNull();
         assertThat(result.get(1).recordedAt()).isNull();
+    }
+
+    @Test
+    void 당일_복약_기록이_없어도_전체_스케줄을_미복용_상태로_반환한다() {
+        LocalDate date = LocalDate.of(2026, 6, 1);
+        Elder elder = createElder(10L);
+        Medicine morningMedicine = createMedicine(1L, elder, "혈압약", LocalTime.of(8, 0));
+        Medicine afternoonMedicine = createMedicine(2L, elder, "당뇨약", LocalTime.of(13, 0));
+        Device device = Device.create(elder, "serial-number");
+        ReflectionTestUtils.setField(device, "id", 30L);
+
+        when(elderQueryService.getElderByMemberId(100L)).thenReturn(elder);
+        when(medicineRepository.findAllByElderIdOrderByScheduledTimeAsc(10L))
+                .thenReturn(List.of(morningMedicine, afternoonMedicine));
+        when(medicationRecordRepository.findAllByElderIdAndRecordedAtBetween(
+                10L, date.atStartOfDay(), date.atTime(LocalTime.MAX)))
+                .thenReturn(List.of());
+        when(deviceSlotQueryService.getSlotMapByElderId(10L))
+                .thenReturn(Map.of(
+                        1L, DeviceSlot.create(elder, device, morningMedicine, 1),
+                        2L, DeviceSlot.create(elder, device, afternoonMedicine, 2)
+                ));
+
+        List<DailyMedicationStatusResponse> result =
+                medicationRecordQueryService.getDailyMedicationStatuses(100L, date);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allSatisfy(response -> {
+            assertThat(response.taken()).isFalse();
+            assertThat(response.result()).isNull();
+            assertThat(response.recordedAt()).isNull();
+        });
+    }
+
+    @Test
+    void 스케줄에_연결된_디바이스_슬롯이_없으면_예외가_발생한다() {
+        LocalDate date = LocalDate.of(2026, 6, 1);
+        Elder elder = createElder(10L);
+        Medicine medicine = createMedicine(1L, elder, "혈압약", LocalTime.of(8, 0));
+
+        when(elderQueryService.getElderByMemberId(100L)).thenReturn(elder);
+        when(medicineRepository.findAllByElderIdOrderByScheduledTimeAsc(10L))
+                .thenReturn(List.of(medicine));
+        when(medicationRecordRepository.findAllByElderIdAndRecordedAtBetween(
+                10L, date.atStartOfDay(), date.atTime(LocalTime.MAX)))
+                .thenReturn(List.of());
+        when(deviceSlotQueryService.getSlotMapByElderId(10L)).thenReturn(Map.of());
+
+        assertThatThrownBy(() -> medicationRecordQueryService.getDailyMedicationStatuses(100L, date))
+                .isInstanceOf(GeneralException.class)
+                .extracting("errorStatus")
+                .isEqualTo(ErrorStatus.DEVICE_NOT_FOUND);
     }
 
     private Elder createElder(Long id) {

--- a/src/test/java/com/ssu/ongi/domain/medicine/service/MedicationRecordQueryServiceTest.java
+++ b/src/test/java/com/ssu/ongi/domain/medicine/service/MedicationRecordQueryServiceTest.java
@@ -1,0 +1,103 @@
+package com.ssu.ongi.domain.medicine.service;
+
+import com.ssu.ongi.domain.device.entity.Device;
+import com.ssu.ongi.domain.device.entity.DeviceSlot;
+import com.ssu.ongi.domain.device.service.DeviceSlotQueryService;
+import com.ssu.ongi.domain.elder.entity.Elder;
+import com.ssu.ongi.domain.elder.service.ElderQueryService;
+import com.ssu.ongi.domain.medicine.dto.response.DailyMedicationStatusResponse;
+import com.ssu.ongi.domain.medicine.entity.MedicationRecord;
+import com.ssu.ongi.domain.medicine.entity.Medicine;
+import com.ssu.ongi.domain.medicine.enums.MedicationResult;
+import com.ssu.ongi.domain.medicine.repository.MedicationRecordRepository;
+import com.ssu.ongi.domain.medicine.repository.MedicineRepository;
+import com.ssu.ongi.domain.member.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MedicationRecordQueryServiceTest {
+
+    private MedicationRecordRepository medicationRecordRepository;
+    private MedicineRepository medicineRepository;
+    private ElderQueryService elderQueryService;
+    private DeviceSlotQueryService deviceSlotQueryService;
+    private MedicationRecordQueryService medicationRecordQueryService;
+
+    @BeforeEach
+    void setUp() {
+        medicationRecordRepository = mock(MedicationRecordRepository.class);
+        medicineRepository = mock(MedicineRepository.class);
+        elderQueryService = mock(ElderQueryService.class);
+        deviceSlotQueryService = mock(DeviceSlotQueryService.class);
+        medicationRecordQueryService = new MedicationRecordQueryService(
+                medicationRecordRepository, medicineRepository, elderQueryService, deviceSlotQueryService);
+    }
+
+    @Test
+    void 날짜별_복약_상태는_전체_스케줄에_해당_날짜_기록을_붙여서_반환한다() {
+        LocalDate date = LocalDate.of(2026, 6, 1);
+        Elder elder = createElder(10L);
+        Medicine takenMedicine = createMedicine(1L, elder, "혈압약", LocalTime.of(8, 0));
+        Medicine pendingMedicine = createMedicine(2L, elder, "당뇨약", LocalTime.of(13, 0));
+        Device device = Device.create(elder, "serial-number");
+        ReflectionTestUtils.setField(device, "id", 30L);
+        DeviceSlot takenSlot = DeviceSlot.create(elder, device, takenMedicine, 1);
+        DeviceSlot pendingSlot = DeviceSlot.create(elder, device, pendingMedicine, 2);
+        MedicationRecord record = MedicationRecord.create(
+                takenMedicine, device, MedicationResult.TAKEN, LocalDateTime.of(2026, 6, 1, 8, 3));
+
+        when(elderQueryService.getElderByMemberId(100L)).thenReturn(elder);
+        when(medicineRepository.findAllByElderIdOrderByScheduledTimeAsc(10L))
+                .thenReturn(List.of(takenMedicine, pendingMedicine));
+        when(medicationRecordRepository.findAllByElderIdAndRecordedAtBetween(
+                10L, date.atStartOfDay(), date.atTime(LocalTime.MAX)))
+                .thenReturn(List.of(record));
+        when(deviceSlotQueryService.getSlotMapByElderId(10L))
+                .thenReturn(Map.of(1L, takenSlot, 2L, pendingSlot));
+
+        List<DailyMedicationStatusResponse> result =
+                medicationRecordQueryService.getDailyMedicationStatuses(100L, date);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).medicineId()).isEqualTo(1L);
+        assertThat(result.get(0).medicineName()).isEqualTo("혈압약");
+        assertThat(result.get(0).slotNumber()).isEqualTo(1);
+        assertThat(result.get(0).deviceId()).isEqualTo(30L);
+        assertThat(result.get(0).taken()).isTrue();
+        assertThat(result.get(0).result()).isEqualTo(MedicationResult.TAKEN);
+        assertThat(result.get(0).recordedAt()).isEqualTo(LocalDateTime.of(2026, 6, 1, 8, 3));
+
+        assertThat(result.get(1).medicineId()).isEqualTo(2L);
+        assertThat(result.get(1).medicineName()).isEqualTo("당뇨약");
+        assertThat(result.get(1).slotNumber()).isEqualTo(2);
+        assertThat(result.get(1).deviceId()).isEqualTo(30L);
+        assertThat(result.get(1).taken()).isFalse();
+        assertThat(result.get(1).result()).isNull();
+        assertThat(result.get(1).recordedAt()).isNull();
+    }
+
+    private Elder createElder(Long id) {
+        Member member = Member.create("guardian", "encoded-pw", "보호자", "01000000000");
+        Elder elder = Elder.create("어르신", 80, "부");
+        member.addElder(elder);
+        ReflectionTestUtils.setField(elder, "id", id);
+        return elder;
+    }
+
+    private Medicine createMedicine(Long id, Elder elder, String name, LocalTime scheduledTime) {
+        Medicine medicine = Medicine.create(elder, name, scheduledTime);
+        ReflectionTestUtils.setField(medicine, "id", id);
+        return medicine;
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

closed #59

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🧩 작업 내용

홈 화면에서 오늘의 복약 스케줄과 각 약의 복약 완료 여부를 한 번에 표시할 수 있도록, 스케줄 목록과 날짜별 복약 기록을 합쳐서 반환하는 통합 조회 API를 추가했습니다.

### 변경 사항

- `DailyMedicationStatusResponse`: 스케줄 정보(`medicineId`, `scheduledTime`, `slotNumber`)와 복약 상태(`taken`, `result`, `recordedAt`)를 함께 담는 응답 DTO 추가
- `MedicationRecordQueryService.getDailyMedicationStatuses()`: 로그인한 보호자의 어르신 전체 스케줄을 조회하고, 해당 날짜의 복약 기록을 `medicineId` 기준으로 merge하여 반환. 당일 동일 약에 여러 기록이 있으면 `recordedAt` 기준 최신 기록 선택
- `GET /api/medicine/medications/daily?date=`: 위 서비스를 호출하는 엔드포인트 추가. `principal.memberId()` 기준으로 어르신을 조회하여 `elderId`를 프론트에서 넘기지 않아도 됨
- `MedicationRecordControllerDocs`: 위 엔드포인트 Swagger 문서 추가
- `MedicationRecordQueryServiceTest`: 복약 기록 있는 경우 / 전체 미복약 / DeviceSlot 없는 예외 케이스 테스트 추가

### 동작 흐름

`GET /api/medicine/medications/daily?date=` → `memberId`로 `elderId` 조회 → 전체 스케줄 조회 + 날짜 범위 복약 기록 조회 → `medicineId` 기준 Map merge → `DailyMedicationStatusResponse` 리스트 반환

## 📸 스크린샷(선택)

해당 없음

📣 **To Reviewers**

---

기존 `GET /api/medicine/medications?elderId=&date=`(실제 복약 기록만 반환)는 그대로 유지되며, 새 API는 홈 화면 표시용으로 미복약 항목도 포함한 전체 상태를 반환합니다.

- Reviewers : 팀 선택
- Labels : feat
