### PR TITLE
[Feat] 디바이스 스케줄 조회 API 추가

### DIFF
--- a/src/main/java/com/ssu/ongi/common/config/SecurityConfig.java
+++ b/src/main/java/com/ssu/ongi/common/config/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
     // ESP32 전용 경로 — JWT 없이 Device-Token 헤더로 인증
     private static final String[] DEVICE_ONLY_URIS = {
             "/api/device/heartbeat",
+            "/api/device/schedules",
             "/api/device/medication-status"
     };
 

--- a/src/main/java/com/ssu/ongi/common/filter/DeviceAuthFilter.java
+++ b/src/main/java/com/ssu/ongi/common/filter/DeviceAuthFilter.java
@@ -29,6 +29,7 @@ public class DeviceAuthFilter extends OncePerRequestFilter {
     // ESP32 전용 경로 — Device-Token 헤더로 인증
     private static final List<String> DEVICE_ONLY_PATHS = List.of(
             "/api/device/heartbeat",
+            "/api/device/schedules",
             "/api/device/medication-status"
     );
 

--- a/src/main/java/com/ssu/ongi/common/status/SuccessStatus.java
+++ b/src/main/java/com/ssu/ongi/common/status/SuccessStatus.java
@@ -49,6 +49,7 @@ public enum SuccessStatus implements BaseStatus {
     DEVICE_CONNECTION_SUCCESS(HttpStatus.OK, "DEVICE_200", "디바이스가 연결되었습니다."),
     DEVICE_REGISTER_SUCCESS(HttpStatus.CREATED, "DEVICE_201", "디바이스가 등록되었습니다."),
     DEVICE_STATUS_GET_SUCCESS(HttpStatus.OK, "DEVICE_200", "디바이스 상태 조회에 성공했습니다."),
+    DEVICE_SCHEDULE_GET_SUCCESS(HttpStatus.OK, "DEVICE_200", "디바이스 스케줄 조회에 성공했습니다."),
     DEVICE_OPEN_ALL_SUCCESS(HttpStatus.OK, "DEVICE_200", "전체 약통 열기 명령을 전달했습니다."),
     DEVICE_CLOSE_ALL_SUCCESS(HttpStatus.OK, "DEVICE_200", "전체 약통 닫기 명령을 전달했습니다."),
     MEDICATION_STATUS_UPDATE_SUCCESS(HttpStatus.OK, "DEVICE_200", "복약 상태가 업데이트되었습니다.");

--- a/src/main/java/com/ssu/ongi/domain/device/controller/DeviceController.java
+++ b/src/main/java/com/ssu/ongi/domain/device/controller/DeviceController.java
@@ -7,6 +7,7 @@ import com.ssu.ongi.domain.device.controller.docs.DeviceControllerDocs;
 import com.ssu.ongi.domain.device.dto.request.DeviceRegisterRequest;
 import com.ssu.ongi.domain.device.dto.request.HeartbeatRequest;
 import com.ssu.ongi.domain.device.dto.request.MedicationStatusRequest;
+import com.ssu.ongi.domain.device.dto.response.DeviceScheduleResponse;
 import com.ssu.ongi.domain.device.dto.response.DeviceStatusResponse;
 import com.ssu.ongi.domain.device.dto.response.RegisterDeviceResponse;
 import com.ssu.ongi.domain.device.service.DeviceCommandService;
@@ -21,6 +22,8 @@ import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/device")
@@ -50,6 +53,15 @@ public class DeviceController implements DeviceControllerDocs {
     ) {
         DeviceStatusResponse response = deviceQueryService.getDeviceStatus(principal.memberId(), principal.loginMode());
         return ApiResponse.success(SuccessStatus.DEVICE_STATUS_GET_SUCCESS, response);
+    }
+
+    @Override
+    @GetMapping("/schedules")
+    public ResponseEntity<ApiResponse<List<DeviceScheduleResponse>>> getDeviceSchedules(
+            @RequestAttribute Long deviceId
+    ) {
+        List<DeviceScheduleResponse> response = deviceQueryService.getDeviceSchedules(deviceId);
+        return ApiResponse.success(SuccessStatus.DEVICE_SCHEDULE_GET_SUCCESS, response);
     }
 
     @Override

--- a/src/main/java/com/ssu/ongi/domain/device/controller/docs/DeviceControllerDocs.java
+++ b/src/main/java/com/ssu/ongi/domain/device/controller/docs/DeviceControllerDocs.java
@@ -5,6 +5,7 @@ import com.ssu.ongi.common.response.ApiResponse;
 import com.ssu.ongi.domain.device.dto.request.DeviceRegisterRequest;
 import com.ssu.ongi.domain.device.dto.request.HeartbeatRequest;
 import com.ssu.ongi.domain.device.dto.request.MedicationStatusRequest;
+import com.ssu.ongi.domain.device.dto.response.DeviceScheduleResponse;
 import com.ssu.ongi.domain.device.dto.response.DeviceStatusResponse;
 import com.ssu.ongi.domain.device.dto.response.RegisterDeviceResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,6 +20,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
 
 @Tag(name = "Device", description = "기기 API")
 public interface DeviceControllerDocs {
@@ -84,6 +87,31 @@ public interface DeviceControllerDocs {
     })
     ResponseEntity<ApiResponse<DeviceStatusResponse>> getDeviceStatus(
             @AuthenticationPrincipal MemberPrincipal principal
+    );
+
+    @Operation(summary = "디바이스 스케줄 조회", description = "디바이스가 자신의 슬롯별 복약 시간을 조회합니다.")
+    @Parameter(name = "Device-Token", in = ParameterIn.HEADER, required = true, description = "디바이스 인증 토큰")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "디바이스 스케줄 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": true,
+                                        "code": "DEVICE_200",
+                                        "message": "디바이스 스케줄 조회에 성공했습니다.",
+                                        "data": [
+                                            {
+                                                "slotNumber": 1,
+                                                "scheduledTime": "08:00:00"
+                                            }
+                                        ]
+                                    }
+                                    """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Device-Token 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "등록되지 않은 디바이스 토큰")
+    })
+    ResponseEntity<ApiResponse<List<DeviceScheduleResponse>>> getDeviceSchedules(
+            @Parameter(hidden = true) @RequestAttribute Long deviceId
     );
 
     @Operation(summary = "디바이스 heartbeat", description = "디바이스의 연결 상태를 업데이트합니다.")

--- a/src/main/java/com/ssu/ongi/domain/device/dto/response/DeviceScheduleResponse.java
+++ b/src/main/java/com/ssu/ongi/domain/device/dto/response/DeviceScheduleResponse.java
@@ -1,0 +1,17 @@
+package com.ssu.ongi.domain.device.dto.response;
+
+import com.ssu.ongi.domain.device.entity.DeviceSlot;
+
+import java.time.LocalTime;
+
+public record DeviceScheduleResponse(
+        Integer slotNumber,
+        LocalTime scheduledTime
+) {
+    public static DeviceScheduleResponse from(DeviceSlot deviceSlot) {
+        return new DeviceScheduleResponse(
+                deviceSlot.getSlotNumber(),
+                deviceSlot.getMedicine().getScheduledTime()
+        );
+    }
+}

--- a/src/main/java/com/ssu/ongi/domain/device/repository/DeviceSlotRepository.java
+++ b/src/main/java/com/ssu/ongi/domain/device/repository/DeviceSlotRepository.java
@@ -25,6 +25,12 @@ public interface DeviceSlotRepository extends JpaRepository<DeviceSlot, Long> {
     Optional<DeviceSlot> findByDeviceIdAndSlotNumber(Long deviceId, Integer slotNumber);
 
     @Query("SELECT ds FROM DeviceSlot ds " +
+            "JOIN FETCH ds.medicine " +
+            "WHERE ds.device.id = :deviceId " +
+            "ORDER BY ds.slotNumber ASC")
+    List<DeviceSlot> findAllWithMedicineByDeviceId(@Param("deviceId") Long deviceId);
+
+    @Query("SELECT ds FROM DeviceSlot ds " +
             "JOIN FETCH ds.elder e " +
             "JOIN FETCH e.member " +
             "JOIN FETCH ds.medicine " +

--- a/src/main/java/com/ssu/ongi/domain/device/service/DeviceQueryService.java
+++ b/src/main/java/com/ssu/ongi/domain/device/service/DeviceQueryService.java
@@ -2,9 +2,11 @@ package com.ssu.ongi.domain.device.service;
 
 import com.ssu.ongi.common.exception.GeneralException;
 import com.ssu.ongi.common.status.ErrorStatus;
+import com.ssu.ongi.domain.device.dto.response.DeviceScheduleResponse;
 import com.ssu.ongi.domain.device.dto.response.DeviceStatusResponse;
 import com.ssu.ongi.domain.device.entity.Device;
 import com.ssu.ongi.domain.device.repository.DeviceRepository;
+import com.ssu.ongi.domain.device.repository.DeviceSlotRepository;
 import com.ssu.ongi.domain.elder.entity.Elder;
 import com.ssu.ongi.domain.elder.service.ElderQueryService;
 import com.ssu.ongi.domain.member.enums.LoginMode;
@@ -13,12 +15,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class DeviceQueryService {
 
     private final DeviceRepository deviceRepository;
+    private final DeviceSlotRepository deviceSlotRepository;
     private final ElderQueryService elderQueryService;
     private final LoginModeValidator loginModeValidator;
 
@@ -46,5 +51,15 @@ public class DeviceQueryService {
         Elder elder = elderQueryService.getElderByMemberId(memberId);
         Device device = getDeviceByElderId(elder.getId());
         return DeviceStatusResponse.from(device);
+    }
+
+    /**
+     * 디바이스가 자신의 슬롯별 복약 시간을 조회합니다.
+     */
+    public List<DeviceScheduleResponse> getDeviceSchedules(Long deviceId) {
+        return deviceSlotRepository.findAllWithMedicineByDeviceId(deviceId)
+                .stream()
+                .map(DeviceScheduleResponse::from)
+                .toList();
     }
 }

--- a/src/test/java/com/ssu/ongi/domain/device/service/DeviceQueryServiceTest.java
+++ b/src/test/java/com/ssu/ongi/domain/device/service/DeviceQueryServiceTest.java
@@ -2,12 +2,16 @@ package com.ssu.ongi.domain.device.service;
 
 import com.ssu.ongi.common.exception.GeneralException;
 import com.ssu.ongi.common.status.ErrorStatus;
+import com.ssu.ongi.domain.device.dto.response.DeviceScheduleResponse;
 import com.ssu.ongi.domain.device.dto.response.DeviceStatusResponse;
 import com.ssu.ongi.domain.device.entity.Device;
+import com.ssu.ongi.domain.device.entity.DeviceSlot;
 import com.ssu.ongi.domain.device.enums.DeviceStatus;
 import com.ssu.ongi.domain.device.repository.DeviceRepository;
+import com.ssu.ongi.domain.device.repository.DeviceSlotRepository;
 import com.ssu.ongi.domain.elder.entity.Elder;
 import com.ssu.ongi.domain.elder.service.ElderQueryService;
+import com.ssu.ongi.domain.medicine.entity.Medicine;
 import com.ssu.ongi.domain.member.enums.LoginMode;
 import com.ssu.ongi.domain.member.service.LoginModeValidator;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,14 +32,17 @@ import static org.mockito.Mockito.when;
 class DeviceQueryServiceTest {
 
     private DeviceRepository deviceRepository;
+    private DeviceSlotRepository deviceSlotRepository;
     private ElderQueryService elderQueryService;
     private DeviceQueryService deviceQueryService;
 
     @BeforeEach
     void setUp() {
         deviceRepository = mock(DeviceRepository.class);
+        deviceSlotRepository = mock(DeviceSlotRepository.class);
         elderQueryService = mock(ElderQueryService.class);
-        deviceQueryService = new DeviceQueryService(deviceRepository, elderQueryService, new LoginModeValidator());
+        deviceQueryService = new DeviceQueryService(
+                deviceRepository, deviceSlotRepository, elderQueryService, new LoginModeValidator());
     }
 
     /**
@@ -109,6 +118,27 @@ class DeviceQueryServiceTest {
         verifyNoInteractions(deviceRepository);
     }
 
+    @Test
+    void 디바이스_스케줄을_슬롯_번호와_시간으로_조회한다() {
+        Elder elder = createElder(1L);
+        Device device = createDevice(10L, elder, "ONGI-001", DeviceStatus.ONLINE, -60, 3600L);
+        Medicine morningMedicine = createMedicine(100L, elder, "혈압약", LocalTime.of(8, 0));
+        Medicine afternoonMedicine = createMedicine(101L, elder, "당뇨약", LocalTime.of(13, 0));
+        DeviceSlot morningSlot = DeviceSlot.create(elder, device, morningMedicine, 1);
+        DeviceSlot afternoonSlot = DeviceSlot.create(elder, device, afternoonMedicine, 2);
+
+        when(deviceSlotRepository.findAllWithMedicineByDeviceId(10L))
+                .thenReturn(List.of(morningSlot, afternoonSlot));
+
+        List<DeviceScheduleResponse> response = deviceQueryService.getDeviceSchedules(10L);
+
+        assertThat(response).hasSize(2);
+        assertThat(response.get(0).slotNumber()).isEqualTo(1);
+        assertThat(response.get(0).scheduledTime()).isEqualTo(LocalTime.of(8, 0));
+        assertThat(response.get(1).slotNumber()).isEqualTo(2);
+        assertThat(response.get(1).scheduledTime()).isEqualTo(LocalTime.of(13, 0));
+    }
+
     /**
      * 테스트용 어르신 엔티티에 식별자를 설정합니다.
      */
@@ -130,5 +160,11 @@ class DeviceQueryServiceTest {
         ReflectionTestUtils.setField(device, "uptimeSec", uptimeSec);
         ReflectionTestUtils.setField(device, "lastSeenAt", LocalDateTime.now());
         return device;
+    }
+
+    private Medicine createMedicine(Long id, Elder elder, String name, LocalTime scheduledTime) {
+        Medicine medicine = Medicine.create(elder, name, scheduledTime);
+        ReflectionTestUtils.setField(medicine, "id", id);
+        return medicine;
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

closed #61

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.

## 🧩 작업 내용

ESP32 장치가 부팅 또는 스케줄 업데이트 시점에 자신의 복약 스케줄을 서버로부터 받아올 수 있도록 디바이스 전용 스케줄 조회 API를 추가했습니다.

### 변경 사항

- `DeviceScheduleResponse`: 슬롯 번호와 복약 시간만 담는 디바이스 응답 DTO 추가
- `DeviceSlotRepository.findAllWithMedicineByDeviceId()`: `deviceId` 기준 슬롯 전체를 `medicine` fetch join으로 조회하는 쿼리 추가
- `DeviceQueryService.getDeviceSchedules()`: deviceId로 슬롯 목록 조회 후 DTO 변환
- `GET /api/device/schedules`: `Device-Token` 헤더로 인증하며, request attribute의 `deviceId`를 사용하는 엔드포인트 추가
- `DeviceAuthFilter`, `SecurityConfig`: `/api/device/schedules` 경로를 디바이스 전용 경로 목록에 추가
- `DeviceQueryServiceTest`: 스케줄 조회 케이스 테스트 추가

## 📸 스크린샷(선택)

해당 없음

📣 **To Reviewers**

---

`DEVICE_ONLY` 경로 이중 관리 구조는 기존부터 있던 문제로, 이번 PR에서는 두 곳 모두 올바르게 추가했습니다. 단일화 리팩토링은 #62 이슈로 분리했습니다.

- Reviewers : 팀 선택
- Labels : feat
