### PR TITLE
[Refactor] DEVICE_ONLY 경로 이중 관리 단일화

### DIFF
--- a/src/main/java/com/ssu/ongi/common/config/SecurityConfig.java
+++ b/src/main/java/com/ssu/ongi/common/config/SecurityConfig.java
@@ -50,12 +50,6 @@ public class SecurityConfig {
             "/api/health"
     };
 
-    // ESP32 전용 경로 — JWT 없이 Device-Token 헤더로 인증
-    private static final String[] DEVICE_ONLY_URIS = {
-            "/api/device/heartbeat",
-            "/api/device/schedules",
-            "/api/device/medication-status"
-    };
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -67,7 +61,7 @@ public class SecurityConfig {
                         .requestMatchers(SWAGGER_URIS).permitAll()
                         .requestMatchers(AUTH_URIS).permitAll()
                         .requestMatchers(HEALTH_URIS).permitAll()
-                        .requestMatchers(DEVICE_ONLY_URIS).permitAll()
+                        .requestMatchers(DeviceAuthFilter.DEVICE_ONLY_PATHS.toArray(String[]::new)).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/ssu/ongi/common/config/SecurityConfig.java
+++ b/src/main/java/com/ssu/ongi/common/config/SecurityConfig.java
@@ -51,6 +51,13 @@ public class SecurityConfig {
     };
 
 
+    // ESP32 전용 경로 — JWT 없이 Device-Token 헤더로 인증
+    public static final String[] DEVICE_ONLY_URIS = {
+            "/api/device/heartbeat",
+            "/api/device/schedules",
+            "/api/device/medication-status"
+    };
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -61,7 +68,7 @@ public class SecurityConfig {
                         .requestMatchers(SWAGGER_URIS).permitAll()
                         .requestMatchers(AUTH_URIS).permitAll()
                         .requestMatchers(HEALTH_URIS).permitAll()
-                        .requestMatchers(DeviceAuthFilter.DEVICE_ONLY_PATHS.toArray(String[]::new)).permitAll()
+                        .requestMatchers(DEVICE_ONLY_URIS).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/ssu/ongi/common/filter/DeviceAuthFilter.java
+++ b/src/main/java/com/ssu/ongi/common/filter/DeviceAuthFilter.java
@@ -1,6 +1,7 @@
 package com.ssu.ongi.common.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssu.ongi.common.config.SecurityConfig;
 import com.ssu.ongi.common.device.DeviceTokenValidator;
 import com.ssu.ongi.common.response.ApiResponse;
 import com.ssu.ongi.common.status.ErrorStatus;
@@ -26,12 +27,8 @@ public class DeviceAuthFilter extends OncePerRequestFilter {
 
     private static final String DEVICE_TOKEN_HEADER = "Device-Token";
 
-    // ESP32 전용 경로 — Device-Token 헤더로 인증. SecurityConfig에서도 참조합니다.
-    public static final List<String> DEVICE_ONLY_PATHS = List.of(
-            "/api/device/heartbeat",
-            "/api/device/schedules",
-            "/api/device/medication-status"
-    );
+    // ESP32 전용 경로 — SecurityConfig.DEVICE_ONLY_URIS를 단일 진실 공급원으로 참조합니다.
+    private static final List<String> DEVICE_ONLY_PATHS = List.of(SecurityConfig.DEVICE_ONLY_URIS);
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/src/main/java/com/ssu/ongi/common/filter/DeviceAuthFilter.java
+++ b/src/main/java/com/ssu/ongi/common/filter/DeviceAuthFilter.java
@@ -26,8 +26,8 @@ public class DeviceAuthFilter extends OncePerRequestFilter {
 
     private static final String DEVICE_TOKEN_HEADER = "Device-Token";
 
-    // ESP32 전용 경로 — Device-Token 헤더로 인증
-    private static final List<String> DEVICE_ONLY_PATHS = List.of(
+    // ESP32 전용 경로 — Device-Token 헤더로 인증. SecurityConfig에서도 참조합니다.
+    public static final List<String> DEVICE_ONLY_PATHS = List.of(
             "/api/device/heartbeat",
             "/api/device/schedules",
             "/api/device/medication-status"


### PR DESCRIPTION
## #️⃣ 관련 이슈

closed #62

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.

## 🧩 작업 내용

디바이스 전용 경로가 `SecurityConfig`와 `DeviceAuthFilter` 두 곳에 중복 관리되던 구조를 개선했습니다. 새 경로 추가 시 한 쪽을 누락하면 인증 흐름이 깨지는 위험을 제거하기 위해 `DeviceAuthFilter.DEVICE_ONLY_PATHS`를 단일 진실 공급원으로 통일했습니다.

### 변경 사항

- `DeviceAuthFilter.DEVICE_ONLY_PATHS`: `private` → `public static`으로 변경하여 외부 참조 가능하도록 공개
- `SecurityConfig`: `DEVICE_ONLY_URIS` 배열 제거 후 `DeviceAuthFilter.DEVICE_ONLY_PATHS`를 직접 참조하도록 변경

## 📸 스크린샷(선택)

해당 없음

📣 **To Reviewers**

---

동작 변경 없이 구조만 개선한 리팩토링입니다. 이후 디바이스 전용 경로 추가 시 `DeviceAuthFilter.DEVICE_ONLY_PATHS` 한 곳만 수정하면 됩니다.

- Reviewers : 팀 선택
- Labels : refactor
